### PR TITLE
Adding DeadRun flag to SIRI for ET and VM

### DIFF
--- a/docs/generated/contab/acsb.html
+++ b/docs/generated/contab/acsb.html
@@ -248,7 +248,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-33.1" title="local-type: typedef-33.1">local-type: typedef-33.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-32.1" title="local-type: typedef-32.1">local-type: typedef-32.1</a>
                       </em>
                     </p>
                   </td>
@@ -272,7 +272,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-33.2" title="local-type: typedef-33.2">local-type: typedef-33.2</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-32.2" title="local-type: typedef-32.2">local-type: typedef-32.2</a>
                       </em>
                     </p>
                   </td>
@@ -297,7 +297,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-43.1" title="local-type: typedef-43.1">local-type: typedef-43.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-11.1" title="local-type: typedef-11.1">local-type: typedef-11.1</a>
                       </em>
                     </p>
                   </td>
@@ -544,7 +544,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-43.1" title="local-type: typedef-43.1">local-type: typedef-43.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-11.1" title="local-type: typedef-11.1">local-type: typedef-11.1</a>
                       </em>
                     </p>
                   </td>
@@ -589,8 +589,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-33.1">
-          <h3>1.6. The complex type <code>complexType[acsb:AccessibilityAssessmentStructure]/Limitations#complexType (typedef-33.1)</code>
+        <div class="sect2" id="local-type.typedef-32.1">
+          <h3>1.6. The complex type <code>complexType[acsb:AccessibilityAssessmentStructure]/Limitations#complexType (typedef-32.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -610,7 +610,7 @@
                       <br/>
                       <code>  /Limitations #complexType</code>
                       <br/>
-                      <code>  (typedef-33.1)</code>
+                      <code>  (typedef-32.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -652,8 +652,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-33.2">
-          <h3>1.7. The complex type <code>complexType[acsb:AccessibilityAssessmentStructure]/Suitabilities#complexType (typedef-33.2)</code>
+        <div class="sect2" id="local-type.typedef-32.2">
+          <h3>1.7. The complex type <code>complexType[acsb:AccessibilityAssessmentStructure]/Suitabilities#complexType (typedef-32.2)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -673,7 +673,7 @@
                       <br/>
                       <code>  /Suitabilities #complexType</code>
                       <br/>
-                      <code>  (typedef-33.2)</code>
+                      <code>  (typedef-32.2)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -715,8 +715,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-43.1">
-          <h3>1.8. The complex type <code>element[ifopt:Extensions]#complexType (typedef-43.1)</code>
+        <div class="sect2" id="local-type.typedef-11.1">
+          <h3>1.8. The complex type <code>element[ifopt:Extensions]#complexType (typedef-11.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -736,7 +736,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-43.1)</code>
+                      <code>  (typedef-11.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -752,8 +752,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-43.1">
-          <h3>1.9. The complex type <code>element[ifopt:Extensions]#complexType (typedef-43.1)</code>
+        <div class="sect2" id="local-type.typedef-11.1">
+          <h3>1.9. The complex type <code>element[ifopt:Extensions]#complexType (typedef-11.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -773,7 +773,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-43.1)</code>
+                      <code>  (typedef-11.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -1672,12 +1672,12 @@
                 </tr>
                 <tr>
                   <td colspan="1" rowspan="2" class="tableblock halign-left valign-top">
-                    <p id="local-type.typedef-34.1" class="tableblock">
+                    <p id="local-type.typedef-31.1" class="tableblock">
                       <code>group[acsb:UserNeedGroup]</code>
                       <br/>
                       <code>  /MedicalNeed #simpleType</code>
                       <br/>
-                      <code>  (typedef-34.1)</code>
+                      <code>  (typedef-31.1)</code>
                     </p>
                   </td>
                   <td colspan="2" rowspan="1" class="tableblock halign-left valign-top">
@@ -1844,7 +1844,7 @@
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
                       <em>
-                        <a shape="rect" href="/home/runner/work/SIRI/SIRI/docs/generated/contab/acsb.enum-dict.html#local-enum.typedef-34.1" title="local-type: typedef-34.1">local-type: typedef-34.1</a>
+                        <a shape="rect" href="/home/runner/work/SIRI/SIRI/docs/generated/contab/acsb.enum-dict.html#local-enum.typedef-31.1" title="local-type: typedef-31.1">local-type: typedef-31.1</a>
                       </em>
                     </p>
                   </td>
@@ -2173,7 +2173,7 @@
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
                       <em>
-                        <a shape="rect" href="/home/runner/work/SIRI/SIRI/docs/generated/contab/acsb.enum-dict.html#local-enum.typedef-34.1" title="local-type: typedef-34.1">local-type: typedef-34.1</a>
+                        <a shape="rect" href="/home/runner/work/SIRI/SIRI/docs/generated/contab/acsb.enum-dict.html#local-enum.typedef-31.1" title="local-type: typedef-31.1">local-type: typedef-31.1</a>
                       </em>
                     </p>
                   </td>

--- a/docs/generated/contab/datex2.html
+++ b/docs/generated/contab/datex2.html
@@ -107112,7 +107112,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-59.1" title="local-type: typedef-59.1">local-type: typedef-59.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-29.1" title="local-type: typedef-29.1">local-type: typedef-29.1</a>
                       </em>
                     </p>
                   </td>
@@ -111020,7 +111020,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-59.2" title="local-type: typedef-59.2">local-type: typedef-59.2</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-29.2" title="local-type: typedef-29.2">local-type: typedef-29.2</a>
                       </em>
                     </p>
                   </td>
@@ -111865,7 +111865,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-59.3" title="local-type: typedef-59.3">local-type: typedef-59.3</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-29.3" title="local-type: typedef-29.3">local-type: typedef-29.3</a>
                       </em>
                     </p>
                   </td>
@@ -127573,7 +127573,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-59.4" title="local-type: typedef-59.4">local-type: typedef-59.4</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-29.4" title="local-type: typedef-29.4">local-type: typedef-29.4</a>
                       </em>
                     </p>
                   </td>
@@ -145442,8 +145442,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-59.1">
-          <h3>2.327. The complex type <code>complexType[Itinerary]/locationContainedInItinerary#complexType (typedef-59.1)</code>
+        <div class="sect2" id="local-type.typedef-29.1">
+          <h3>2.327. The complex type <code>complexType[Itinerary]/locationContainedInItinerary#complexType (typedef-29.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -145463,7 +145463,7 @@
                       <br/>
                       <code>  /locationContainedInItinerary #complexType</code>
                       <br/>
-                      <code>  (typedef-59.1)</code>
+                      <code>  (typedef-29.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -145588,8 +145588,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-59.2">
-          <h3>2.328. The complex type <code>complexType[MeasurementSiteRecord]/measurementSpecificCharacteristics#complexType (typedef-59.2)</code>
+        <div class="sect2" id="local-type.typedef-29.2">
+          <h3>2.328. The complex type <code>complexType[MeasurementSiteRecord]/measurementSpecificCharacteristics#complexType (typedef-29.2)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -145609,7 +145609,7 @@
                       <br/>
                       <code>  /measurementSpecificCharacteristics #complexType</code>
                       <br/>
-                      <code>  (typedef-59.2)</code>
+                      <code>  (typedef-29.2)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -145839,8 +145839,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-59.3">
-          <h3>2.329. The complex type <code>complexType[MultilingualString]/values#complexType (typedef-59.3)</code>
+        <div class="sect2" id="local-type.typedef-29.3">
+          <h3>2.329. The complex type <code>complexType[MultilingualString]/values#complexType (typedef-29.3)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -145860,7 +145860,7 @@
                       <br/>
                       <code>  /values #complexType</code>
                       <br/>
-                      <code>  (typedef-59.3)</code>
+                      <code>  (typedef-29.3)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -145902,8 +145902,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-59.4">
-          <h3>2.330. The complex type <code>complexType[SiteMeasurements]/measuredValue#complexType (typedef-59.4)</code>
+        <div class="sect2" id="local-type.typedef-29.4">
+          <h3>2.330. The complex type <code>complexType[SiteMeasurements]/measuredValue#complexType (typedef-29.4)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -145923,7 +145923,7 @@
                       <br/>
                       <code>  /measuredValue #complexType</code>
                       <br/>
-                      <code>  (typedef-59.4)</code>
+                      <code>  (typedef-29.4)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">

--- a/docs/generated/contab/ifopt.html
+++ b/docs/generated/contab/ifopt.html
@@ -7206,7 +7206,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-53.1" title="local-type: typedef-53.1">local-type: typedef-53.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-3.1" title="local-type: typedef-3.1">local-type: typedef-3.1</a>
                       </em>
                     </p>
                   </td>
@@ -8212,7 +8212,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-53.1" title="local-type: typedef-53.1">local-type: typedef-53.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-3.1" title="local-type: typedef-3.1">local-type: typedef-3.1</a>
                       </em>
                     </p>
                   </td>
@@ -8237,7 +8237,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-43.1" title="local-type: typedef-43.1">local-type: typedef-43.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-11.1" title="local-type: typedef-11.1">local-type: typedef-11.1</a>
                       </em>
                     </p>
                   </td>
@@ -8562,7 +8562,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-43.1" title="local-type: typedef-43.1">local-type: typedef-43.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-11.1" title="local-type: typedef-11.1">local-type: typedef-11.1</a>
                       </em>
                     </p>
                   </td>
@@ -8574,8 +8574,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-53.1">
-          <h3>4.15. The complex type <code>group[ifopt:LocalServiceGroup]/FeatureRefs#complexType (typedef-53.1)</code>
+        <div class="sect2" id="local-type.typedef-3.1">
+          <h3>4.15. The complex type <code>group[ifopt:LocalServiceGroup]/FeatureRefs#complexType (typedef-3.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -8595,7 +8595,7 @@
                       <br/>
                       <code>  /FeatureRefs #complexType</code>
                       <br/>
-                      <code>  (typedef-53.1)</code>
+                      <code>  (typedef-3.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -8633,8 +8633,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-53.1">
-          <h3>4.16. The complex type <code>group[ifopt:LocalServiceGroup]/FeatureRefs#complexType (typedef-53.1)</code>
+        <div class="sect2" id="local-type.typedef-3.1">
+          <h3>4.16. The complex type <code>group[ifopt:LocalServiceGroup]/FeatureRefs#complexType (typedef-3.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -8654,7 +8654,7 @@
                       <br/>
                       <code>  /FeatureRefs #complexType</code>
                       <br/>
-                      <code>  (typedef-53.1)</code>
+                      <code>  (typedef-3.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -8692,8 +8692,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-43.1">
-          <h3>4.17. The complex type <code>element[ifopt:Extensions]#complexType (typedef-43.1)</code>
+        <div class="sect2" id="local-type.typedef-11.1">
+          <h3>4.17. The complex type <code>element[ifopt:Extensions]#complexType (typedef-11.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -8713,7 +8713,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-43.1)</code>
+                      <code>  (typedef-11.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -8729,8 +8729,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-43.1">
-          <h3>4.18. The complex type <code>element[ifopt:Extensions]#complexType (typedef-43.1)</code>
+        <div class="sect2" id="local-type.typedef-11.1">
+          <h3>4.18. The complex type <code>element[ifopt:Extensions]#complexType (typedef-11.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -8750,7 +8750,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-43.1)</code>
+                      <code>  (typedef-11.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -9391,7 +9391,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-46.1" title="local-type: typedef-46.1">local-type: typedef-46.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-9.1" title="local-type: typedef-9.1">local-type: typedef-9.1</a>
                       </em>
                     </p>
                   </td>
@@ -9568,7 +9568,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-46.1" title="local-type: typedef-46.1">local-type: typedef-46.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-9.1" title="local-type: typedef-9.1">local-type: typedef-9.1</a>
                       </em>
                     </p>
                   </td>
@@ -9597,7 +9597,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-46.2" title="local-type: typedef-46.2">local-type: typedef-46.2</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-9.2" title="local-type: typedef-9.2">local-type: typedef-9.2</a>
                       </em>
                     </p>
                   </td>
@@ -9659,7 +9659,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-46.1" title="local-type: typedef-46.1">local-type: typedef-46.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-9.1" title="local-type: typedef-9.1">local-type: typedef-9.1</a>
                       </em>
                     </p>
                   </td>
@@ -9908,7 +9908,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-46.1" title="local-type: typedef-46.1">local-type: typedef-46.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-9.1" title="local-type: typedef-9.1">local-type: typedef-9.1</a>
                       </em>
                     </p>
                   </td>
@@ -9941,7 +9941,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-46.3" title="local-type: typedef-46.3">local-type: typedef-46.3</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-9.3" title="local-type: typedef-9.3">local-type: typedef-9.3</a>
                       </em>
                     </p>
                   </td>
@@ -9953,8 +9953,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-46.1">
-          <h3>5.17. The complex type <code>complexType[ifopt:AbstractProjection]/Features#complexType (typedef-46.1)</code>
+        <div class="sect2" id="local-type.typedef-9.1">
+          <h3>5.17. The complex type <code>complexType[ifopt:AbstractProjection]/Features#complexType (typedef-9.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -9974,7 +9974,7 @@
                       <br/>
                       <code>  /Features #complexType</code>
                       <br/>
-                      <code>  (typedef-46.1)</code>
+                      <code>  (typedef-9.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -10016,8 +10016,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-46.1">
-          <h3>5.18. The complex type <code>complexType[ifopt:AbstractProjection]/Features#complexType (typedef-46.1)</code>
+        <div class="sect2" id="local-type.typedef-9.1">
+          <h3>5.18. The complex type <code>complexType[ifopt:AbstractProjection]/Features#complexType (typedef-9.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -10037,7 +10037,7 @@
                       <br/>
                       <code>  /Features #complexType</code>
                       <br/>
-                      <code>  (typedef-46.1)</code>
+                      <code>  (typedef-9.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -10079,8 +10079,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-46.2">
-          <h3>5.19. The complex type <code>complexType[ifopt:LinkProjectionStructure]/Line#complexType (typedef-46.2)</code>
+        <div class="sect2" id="local-type.typedef-9.2">
+          <h3>5.19. The complex type <code>complexType[ifopt:LinkProjectionStructure]/Line#complexType (typedef-9.2)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -10100,7 +10100,7 @@
                       <br/>
                       <code>  /Line #complexType</code>
                       <br/>
-                      <code>  (typedef-46.2)</code>
+                      <code>  (typedef-9.2)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -10143,8 +10143,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-46.1">
-          <h3>5.20. The complex type <code>complexType[ifopt:AbstractProjection]/Features#complexType (typedef-46.1)</code>
+        <div class="sect2" id="local-type.typedef-9.1">
+          <h3>5.20. The complex type <code>complexType[ifopt:AbstractProjection]/Features#complexType (typedef-9.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -10164,7 +10164,7 @@
                       <br/>
                       <code>  /Features #complexType</code>
                       <br/>
-                      <code>  (typedef-46.1)</code>
+                      <code>  (typedef-9.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -10206,8 +10206,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-46.1">
-          <h3>5.21. The complex type <code>complexType[ifopt:AbstractProjection]/Features#complexType (typedef-46.1)</code>
+        <div class="sect2" id="local-type.typedef-9.1">
+          <h3>5.21. The complex type <code>complexType[ifopt:AbstractProjection]/Features#complexType (typedef-9.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -10227,7 +10227,7 @@
                       <br/>
                       <code>  /Features #complexType</code>
                       <br/>
-                      <code>  (typedef-46.1)</code>
+                      <code>  (typedef-9.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -10269,8 +10269,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-46.3">
-          <h3>5.22. The complex type <code>complexType[ifopt:ZoneProjectionStructure]/Boundary#complexType (typedef-46.3)</code>
+        <div class="sect2" id="local-type.typedef-9.3">
+          <h3>5.22. The complex type <code>complexType[ifopt:ZoneProjectionStructure]/Boundary#complexType (typedef-9.3)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -10290,7 +10290,7 @@
                       <br/>
                       <code>  /Boundary #complexType</code>
                       <br/>
-                      <code>  (typedef-46.3)</code>
+                      <code>  (typedef-9.3)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -13149,7 +13149,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-52.1" title="local-type: typedef-52.1">local-type: typedef-52.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-4.1" title="local-type: typedef-4.1">local-type: typedef-4.1</a>
                       </em>
                     </p>
                   </td>
@@ -13161,8 +13161,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-52.1">
-          <h3>10.5. The complex type <code>complexType[ifopt:ValidityConditionStructure]/Timebands#complexType (typedef-52.1)</code>
+        <div class="sect2" id="local-type.typedef-4.1">
+          <h3>10.5. The complex type <code>complexType[ifopt:ValidityConditionStructure]/Timebands#complexType (typedef-4.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -13182,7 +13182,7 @@
                       <br/>
                       <code>  /Timebands #complexType</code>
                       <br/>
-                      <code>  (typedef-52.1)</code>
+                      <code>  (typedef-4.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -13416,8 +13416,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-43.1">
-          <h3>11.7. The complex type <code>element[ifopt:Extensions]#complexType (typedef-43.1)</code>
+        <div class="sect2" id="local-type.typedef-11.1">
+          <h3>11.7. The complex type <code>element[ifopt:Extensions]#complexType (typedef-11.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -13437,7 +13437,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-43.1)</code>
+                      <code>  (typedef-11.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">

--- a/docs/generated/contab/siri.html
+++ b/docs/generated/contab/siri.html
@@ -5535,7 +5535,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-68.1" title="local-type: typedef-68.1">local-type: typedef-68.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-21.1" title="local-type: typedef-21.1">local-type: typedef-21.1</a>
                       </em>
                     </p>
                   </td>
@@ -5944,7 +5944,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-82.2" title="local-type: typedef-82.2">local-type: typedef-82.2</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-76.2" title="local-type: typedef-76.2">local-type: typedef-76.2</a>
                       </em>
                     </p>
                   </td>
@@ -5975,7 +5975,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-70.2" title="local-type: typedef-70.2">local-type: typedef-70.2</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-22.2" title="local-type: typedef-22.2">local-type: typedef-22.2</a>
                       </em>
                     </p>
                   </td>
@@ -6361,7 +6361,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-82.4" title="local-type: typedef-82.4">local-type: typedef-82.4</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-76.4" title="local-type: typedef-76.4">local-type: typedef-76.4</a>
                       </em>
                     </p>
                   </td>
@@ -6957,7 +6957,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-82.4" title="local-type: typedef-82.4">local-type: typedef-82.4</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-76.4" title="local-type: typedef-76.4">local-type: typedef-76.4</a>
                       </em>
                     </p>
                   </td>
@@ -7063,7 +7063,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-82.2" title="local-type: typedef-82.2">local-type: typedef-82.2</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-76.2" title="local-type: typedef-76.2">local-type: typedef-76.2</a>
                       </em>
                     </p>
                   </td>
@@ -7094,7 +7094,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-82.3" title="local-type: typedef-82.3">local-type: typedef-82.3</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-76.3" title="local-type: typedef-76.3">local-type: typedef-76.3</a>
                       </em>
                     </p>
                   </td>
@@ -7343,7 +7343,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-73.1" title="local-type: typedef-73.1">local-type: typedef-73.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-80.1" title="local-type: typedef-80.1">local-type: typedef-80.1</a>
                       </em>
                     </p>
                   </td>
@@ -7405,7 +7405,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-73.2" title="local-type: typedef-73.2">local-type: typedef-73.2</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-80.2" title="local-type: typedef-80.2">local-type: typedef-80.2</a>
                       </em>
                     </p>
                   </td>
@@ -7736,7 +7736,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-82.4" title="local-type: typedef-82.4">local-type: typedef-82.4</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-76.4" title="local-type: typedef-76.4">local-type: typedef-76.4</a>
                       </em>
                     </p>
                   </td>
@@ -8176,7 +8176,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-68.1" title="local-type: typedef-68.1">local-type: typedef-68.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-21.1" title="local-type: typedef-21.1">local-type: typedef-21.1</a>
                       </em>
                     </p>
                   </td>
@@ -8701,7 +8701,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-82.2" title="local-type: typedef-82.2">local-type: typedef-82.2</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-76.2" title="local-type: typedef-76.2">local-type: typedef-76.2</a>
                       </em>
                     </p>
                   </td>
@@ -8732,7 +8732,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-82.3" title="local-type: typedef-82.3">local-type: typedef-82.3</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-76.3" title="local-type: typedef-76.3">local-type: typedef-76.3</a>
                       </em>
                     </p>
                   </td>
@@ -9004,7 +9004,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-73.1" title="local-type: typedef-73.1">local-type: typedef-73.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-80.1" title="local-type: typedef-80.1">local-type: typedef-80.1</a>
                       </em>
                     </p>
                   </td>
@@ -9066,7 +9066,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-73.2" title="local-type: typedef-73.2">local-type: typedef-73.2</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-80.2" title="local-type: typedef-80.2">local-type: typedef-80.2</a>
                       </em>
                     </p>
                   </td>
@@ -9603,7 +9603,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-74.3" title="local-type: typedef-74.3">local-type: typedef-74.3</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-86.3" title="local-type: typedef-86.3">local-type: typedef-86.3</a>
                       </em>
                     </p>
                   </td>
@@ -11023,7 +11023,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-74.2" title="local-type: typedef-74.2">local-type: typedef-74.2</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-86.2" title="local-type: typedef-86.2">local-type: typedef-86.2</a>
                       </em>
                     </p>
                   </td>
@@ -11601,7 +11601,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-74.3" title="local-type: typedef-74.3">local-type: typedef-74.3</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-86.3" title="local-type: typedef-86.3">local-type: typedef-86.3</a>
                       </em>
                     </p>
                   </td>
@@ -12404,7 +12404,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-68.1" title="local-type: typedef-68.1">local-type: typedef-68.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-21.1" title="local-type: typedef-21.1">local-type: typedef-21.1</a>
                       </em>
                     </p>
                   </td>
@@ -13137,7 +13137,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-68.1" title="local-type: typedef-68.1">local-type: typedef-68.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-21.1" title="local-type: typedef-21.1">local-type: typedef-21.1</a>
                       </em>
                     </p>
                   </td>
@@ -14746,7 +14746,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-74.2" title="local-type: typedef-74.2">local-type: typedef-74.2</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-86.2" title="local-type: typedef-86.2">local-type: typedef-86.2</a>
                       </em>
                     </p>
                   </td>
@@ -15396,7 +15396,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-74.2" title="local-type: typedef-74.2">local-type: typedef-74.2</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-86.2" title="local-type: typedef-86.2">local-type: typedef-86.2</a>
                       </em>
                     </p>
                   </td>
@@ -15718,8 +15718,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-82.4">
-          <h3>1.28. The complex type <code>element[siri:ServiceDelivery]#complexType (typedef-82.4)</code>
+        <div class="sect2" id="local-type.typedef-76.4">
+          <h3>1.28. The complex type <code>element[siri:ServiceDelivery]#complexType (typedef-76.4)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -15739,7 +15739,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-82.4)</code>
+                      <code>  (typedef-76.4)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -15983,7 +15983,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-68.1" title="local-type: typedef-68.1">local-type: typedef-68.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-21.1" title="local-type: typedef-21.1">local-type: typedef-21.1</a>
                       </em>
                     </p>
                   </td>
@@ -16044,8 +16044,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-68.1">
-          <h3>1.29. The complex type <code>group[siri:ServiceDeliveryRequestStatusGroup]/ErrorCondition#complexType (typedef-68.1)</code>
+        <div class="sect2" id="local-type.typedef-21.1">
+          <h3>1.29. The complex type <code>group[siri:ServiceDeliveryRequestStatusGroup]/ErrorCondition#complexType (typedef-21.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -16065,7 +16065,7 @@
                       <br/>
                       <code>  /ErrorCondition #complexType</code>
                       <br/>
-                      <code>  (typedef-68.1)</code>
+                      <code>  (typedef-21.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -16176,8 +16176,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-82.2">
-          <h3>1.30. The complex type <code>element[siri:ServiceRequest]#complexType (typedef-82.2)</code>
+        <div class="sect2" id="local-type.typedef-76.2">
+          <h3>1.30. The complex type <code>element[siri:ServiceRequest]#complexType (typedef-76.2)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -16197,7 +16197,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-82.2)</code>
+                      <code>  (typedef-76.2)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -16431,8 +16431,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-82.1">
-          <h3>1.31. The complex type <code>element[siri:Siri]#complexType (typedef-82.1)</code>
+        <div class="sect2" id="local-type.typedef-76.1">
+          <h3>1.31. The complex type <code>element[siri:Siri]#complexType (typedef-76.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -16452,7 +16452,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-82.1)</code>
+                      <code>  (typedef-76.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -16532,7 +16532,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-82.2" title="local-type: typedef-82.2">local-type: typedef-82.2</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-76.2" title="local-type: typedef-76.2">local-type: typedef-76.2</a>
                       </em>
                     </p>
                   </td>
@@ -16563,7 +16563,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-70.2" title="local-type: typedef-70.2">local-type: typedef-70.2</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-22.2" title="local-type: typedef-22.2">local-type: typedef-22.2</a>
                       </em>
                     </p>
                   </td>
@@ -16949,7 +16949,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-82.4" title="local-type: typedef-82.4">local-type: typedef-82.4</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-76.4" title="local-type: typedef-76.4">local-type: typedef-76.4</a>
                       </em>
                     </p>
                   </td>
@@ -17131,8 +17131,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-82.2">
-          <h3>1.32. The complex type <code>element[siri:ServiceRequest]#complexType (typedef-82.2)</code>
+        <div class="sect2" id="local-type.typedef-76.2">
+          <h3>1.32. The complex type <code>element[siri:ServiceRequest]#complexType (typedef-76.2)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -17152,7 +17152,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-82.2)</code>
+                      <code>  (typedef-76.2)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -17386,8 +17386,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-70.2">
-          <h3>1.33. The complex type <code>element[siri:SubscriptionRequest]#complexType (typedef-70.2)</code>
+        <div class="sect2" id="local-type.typedef-22.2">
+          <h3>1.33. The complex type <code>element[siri:SubscriptionRequest]#complexType (typedef-22.2)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -17407,7 +17407,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-70.2)</code>
+                      <code>  (typedef-22.2)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -17715,8 +17715,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-82.4">
-          <h3>1.34. The complex type <code>element[siri:ServiceDelivery]#complexType (typedef-82.4)</code>
+        <div class="sect2" id="local-type.typedef-76.4">
+          <h3>1.34. The complex type <code>element[siri:ServiceDelivery]#complexType (typedef-76.4)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -17736,7 +17736,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-82.4)</code>
+                      <code>  (typedef-76.4)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -17980,7 +17980,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-68.1" title="local-type: typedef-68.1">local-type: typedef-68.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-21.1" title="local-type: typedef-21.1">local-type: typedef-21.1</a>
                       </em>
                     </p>
                   </td>
@@ -18041,8 +18041,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-68.1">
-          <h3>1.35. The complex type <code>group[siri:ServiceDeliveryRequestStatusGroup]/ErrorCondition#complexType (typedef-68.1)</code>
+        <div class="sect2" id="local-type.typedef-21.1">
+          <h3>1.35. The complex type <code>group[siri:ServiceDeliveryRequestStatusGroup]/ErrorCondition#complexType (typedef-21.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -18062,7 +18062,7 @@
                       <br/>
                       <code>  /ErrorCondition #complexType</code>
                       <br/>
-                      <code>  (typedef-68.1)</code>
+                      <code>  (typedef-21.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -18173,8 +18173,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-82.3">
-          <h3>1.36. The complex type <code>element[siri:SubscriptionRequest]#complexType (typedef-82.3)</code>
+        <div class="sect2" id="local-type.typedef-76.3">
+          <h3>1.36. The complex type <code>element[siri:SubscriptionRequest]#complexType (typedef-76.3)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -18194,7 +18194,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-82.3)</code>
+                      <code>  (typedef-76.3)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -18502,8 +18502,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-82.4">
-          <h3>1.37. The complex type <code>element[siri:ServiceDelivery]#complexType (typedef-82.4)</code>
+        <div class="sect2" id="local-type.typedef-76.4">
+          <h3>1.37. The complex type <code>element[siri:ServiceDelivery]#complexType (typedef-76.4)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -18523,7 +18523,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-82.4)</code>
+                      <code>  (typedef-76.4)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -18767,7 +18767,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-68.1" title="local-type: typedef-68.1">local-type: typedef-68.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-21.1" title="local-type: typedef-21.1">local-type: typedef-21.1</a>
                       </em>
                     </p>
                   </td>
@@ -18828,8 +18828,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-68.1">
-          <h3>1.38. The complex type <code>group[siri:ServiceDeliveryRequestStatusGroup]/ErrorCondition#complexType (typedef-68.1)</code>
+        <div class="sect2" id="local-type.typedef-21.1">
+          <h3>1.38. The complex type <code>group[siri:ServiceDeliveryRequestStatusGroup]/ErrorCondition#complexType (typedef-21.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -18849,7 +18849,7 @@
                       <br/>
                       <code>  /ErrorCondition #complexType</code>
                       <br/>
-                      <code>  (typedef-68.1)</code>
+                      <code>  (typedef-21.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -18960,8 +18960,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-82.2">
-          <h3>1.39. The complex type <code>element[siri:ServiceRequest]#complexType (typedef-82.2)</code>
+        <div class="sect2" id="local-type.typedef-76.2">
+          <h3>1.39. The complex type <code>element[siri:ServiceRequest]#complexType (typedef-76.2)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -18981,7 +18981,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-82.2)</code>
+                      <code>  (typedef-76.2)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -19215,8 +19215,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-82.3">
-          <h3>1.40. The complex type <code>element[siri:SubscriptionRequest]#complexType (typedef-82.3)</code>
+        <div class="sect2" id="local-type.typedef-76.3">
+          <h3>1.40. The complex type <code>element[siri:SubscriptionRequest]#complexType (typedef-76.3)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -19236,7 +19236,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-82.3)</code>
+                      <code>  (typedef-76.3)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -19544,8 +19544,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-73.1">
-          <h3>1.41. The complex type <code>element[siri:StopPointsRequest]#complexType (typedef-73.1)</code>
+        <div class="sect2" id="local-type.typedef-80.1">
+          <h3>1.41. The complex type <code>element[siri:StopPointsRequest]#complexType (typedef-80.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -19565,7 +19565,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-73.1)</code>
+                      <code>  (typedef-80.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -19955,8 +19955,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-73.2">
-          <h3>1.42. The complex type <code>element[siri:ServiceFeaturesRequest]#complexType (typedef-73.2)</code>
+        <div class="sect2" id="local-type.typedef-80.2">
+          <h3>1.42. The complex type <code>element[siri:ServiceFeaturesRequest]#complexType (typedef-80.2)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -19976,7 +19976,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-73.2)</code>
+                      <code>  (typedef-80.2)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -20194,8 +20194,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-82.4">
-          <h3>1.43. The complex type <code>element[siri:ServiceDelivery]#complexType (typedef-82.4)</code>
+        <div class="sect2" id="local-type.typedef-76.4">
+          <h3>1.43. The complex type <code>element[siri:ServiceDelivery]#complexType (typedef-76.4)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -20215,7 +20215,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-82.4)</code>
+                      <code>  (typedef-76.4)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -20459,7 +20459,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-68.1" title="local-type: typedef-68.1">local-type: typedef-68.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-21.1" title="local-type: typedef-21.1">local-type: typedef-21.1</a>
                       </em>
                     </p>
                   </td>
@@ -20520,8 +20520,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-68.1">
-          <h3>1.44. The complex type <code>group[siri:ServiceDeliveryRequestStatusGroup]/ErrorCondition#complexType (typedef-68.1)</code>
+        <div class="sect2" id="local-type.typedef-21.1">
+          <h3>1.44. The complex type <code>group[siri:ServiceDeliveryRequestStatusGroup]/ErrorCondition#complexType (typedef-21.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -20541,7 +20541,7 @@
                       <br/>
                       <code>  /ErrorCondition #complexType</code>
                       <br/>
-                      <code>  (typedef-68.1)</code>
+                      <code>  (typedef-21.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -20652,8 +20652,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-68.1">
-          <h3>1.45. The complex type <code>group[siri:ServiceDeliveryRequestStatusGroup]/ErrorCondition#complexType (typedef-68.1)</code>
+        <div class="sect2" id="local-type.typedef-21.1">
+          <h3>1.45. The complex type <code>group[siri:ServiceDeliveryRequestStatusGroup]/ErrorCondition#complexType (typedef-21.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -20673,7 +20673,7 @@
                       <br/>
                       <code>  /ErrorCondition #complexType</code>
                       <br/>
-                      <code>  (typedef-68.1)</code>
+                      <code>  (typedef-21.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -20784,8 +20784,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-82.2">
-          <h3>1.46. The complex type <code>element[siri:ServiceRequest]#complexType (typedef-82.2)</code>
+        <div class="sect2" id="local-type.typedef-76.2">
+          <h3>1.46. The complex type <code>element[siri:ServiceRequest]#complexType (typedef-76.2)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -20805,7 +20805,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-82.2)</code>
+                      <code>  (typedef-76.2)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -21039,8 +21039,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-82.3">
-          <h3>1.47. The complex type <code>element[siri:SubscriptionRequest]#complexType (typedef-82.3)</code>
+        <div class="sect2" id="local-type.typedef-76.3">
+          <h3>1.47. The complex type <code>element[siri:SubscriptionRequest]#complexType (typedef-76.3)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -21060,7 +21060,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-82.3)</code>
+                      <code>  (typedef-76.3)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -21368,8 +21368,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-73.1">
-          <h3>1.48. The complex type <code>element[siri:StopPointsRequest]#complexType (typedef-73.1)</code>
+        <div class="sect2" id="local-type.typedef-80.1">
+          <h3>1.48. The complex type <code>element[siri:StopPointsRequest]#complexType (typedef-80.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -21389,7 +21389,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-73.1)</code>
+                      <code>  (typedef-80.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -21779,8 +21779,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-73.2">
-          <h3>1.49. The complex type <code>element[siri:ServiceFeaturesRequest]#complexType (typedef-73.2)</code>
+        <div class="sect2" id="local-type.typedef-80.2">
+          <h3>1.49. The complex type <code>element[siri:ServiceFeaturesRequest]#complexType (typedef-80.2)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -21800,7 +21800,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-73.2)</code>
+                      <code>  (typedef-80.2)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -22018,8 +22018,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-74.3">
-          <h3>1.50. The complex type <code>element[siri:ProductionTimetableCapabilitiesRequest]#complexType (typedef-74.3)</code>
+        <div class="sect2" id="local-type.typedef-86.3">
+          <h3>1.50. The complex type <code>element[siri:ProductionTimetableCapabilitiesRequest]#complexType (typedef-86.3)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -22039,7 +22039,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-74.3)</code>
+                      <code>  (typedef-86.3)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -22189,8 +22189,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-74.2">
-          <h3>1.51. The complex type <code>element[siri:ProductionTimetableSubscriptionRequest]#complexType (typedef-74.2)</code>
+        <div class="sect2" id="local-type.typedef-86.2">
+          <h3>1.51. The complex type <code>element[siri:ProductionTimetableSubscriptionRequest]#complexType (typedef-86.2)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -22210,7 +22210,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-74.2)</code>
+                      <code>  (typedef-86.2)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -22407,8 +22407,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-74.3">
-          <h3>1.52. The complex type <code>element[siri:ProductionTimetableCapabilitiesRequest]#complexType (typedef-74.3)</code>
+        <div class="sect2" id="local-type.typedef-86.3">
+          <h3>1.52. The complex type <code>element[siri:ProductionTimetableCapabilitiesRequest]#complexType (typedef-86.3)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -22428,7 +22428,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-74.3)</code>
+                      <code>  (typedef-86.3)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -22578,8 +22578,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-68.1">
-          <h3>1.53. The complex type <code>group[siri:ServiceDeliveryRequestStatusGroup]/ErrorCondition#complexType (typedef-68.1)</code>
+        <div class="sect2" id="local-type.typedef-21.1">
+          <h3>1.53. The complex type <code>group[siri:ServiceDeliveryRequestStatusGroup]/ErrorCondition#complexType (typedef-21.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -22599,7 +22599,7 @@
                       <br/>
                       <code>  /ErrorCondition #complexType</code>
                       <br/>
-                      <code>  (typedef-68.1)</code>
+                      <code>  (typedef-21.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -22710,8 +22710,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-68.1">
-          <h3>1.54. The complex type <code>group[siri:ServiceDeliveryRequestStatusGroup]/ErrorCondition#complexType (typedef-68.1)</code>
+        <div class="sect2" id="local-type.typedef-21.1">
+          <h3>1.54. The complex type <code>group[siri:ServiceDeliveryRequestStatusGroup]/ErrorCondition#complexType (typedef-21.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -22731,7 +22731,7 @@
                       <br/>
                       <code>  /ErrorCondition #complexType</code>
                       <br/>
-                      <code>  (typedef-68.1)</code>
+                      <code>  (typedef-21.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -22842,8 +22842,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-74.2">
-          <h3>1.55. The complex type <code>element[siri:ProductionTimetableSubscriptionRequest]#complexType (typedef-74.2)</code>
+        <div class="sect2" id="local-type.typedef-86.2">
+          <h3>1.55. The complex type <code>element[siri:ProductionTimetableSubscriptionRequest]#complexType (typedef-86.2)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -22863,7 +22863,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-74.2)</code>
+                      <code>  (typedef-86.2)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -23060,8 +23060,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-74.2">
-          <h3>1.56. The complex type <code>element[siri:ProductionTimetableSubscriptionRequest]#complexType (typedef-74.2)</code>
+        <div class="sect2" id="local-type.typedef-86.2">
+          <h3>1.56. The complex type <code>element[siri:ProductionTimetableSubscriptionRequest]#complexType (typedef-86.2)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -23081,7 +23081,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-74.2)</code>
+                      <code>  (typedef-86.2)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -23610,7 +23610,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-68.1" title="local-type: typedef-68.1">local-type: typedef-68.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-21.1" title="local-type: typedef-21.1">local-type: typedef-21.1</a>
                       </em>
                     </p>
                   </td>
@@ -24370,7 +24370,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-82.4" title="local-type: typedef-82.4">local-type: typedef-82.4</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-76.4" title="local-type: typedef-76.4">local-type: typedef-76.4</a>
                       </em>
                     </p>
                   </td>
@@ -24678,7 +24678,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-82.2" title="local-type: typedef-82.2">local-type: typedef-82.2</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-76.2" title="local-type: typedef-76.2">local-type: typedef-76.2</a>
                       </em>
                     </p>
                   </td>
@@ -24709,7 +24709,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-82.3" title="local-type: typedef-82.3">local-type: typedef-82.3</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-76.3" title="local-type: typedef-76.3">local-type: typedef-76.3</a>
                       </em>
                     </p>
                   </td>
@@ -25126,7 +25126,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-82.4" title="local-type: typedef-82.4">local-type: typedef-82.4</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-76.4" title="local-type: typedef-76.4">local-type: typedef-76.4</a>
                       </em>
                     </p>
                   </td>
@@ -25341,7 +25341,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-68.1" title="local-type: typedef-68.1">local-type: typedef-68.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-21.1" title="local-type: typedef-21.1">local-type: typedef-21.1</a>
                       </em>
                     </p>
                   </td>
@@ -25460,7 +25460,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-82.2" title="local-type: typedef-82.2">local-type: typedef-82.2</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-76.2" title="local-type: typedef-76.2">local-type: typedef-76.2</a>
                       </em>
                     </p>
                   </td>
@@ -25491,7 +25491,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-82.3" title="local-type: typedef-82.3">local-type: typedef-82.3</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-76.3" title="local-type: typedef-76.3">local-type: typedef-76.3</a>
                       </em>
                     </p>
                   </td>
@@ -26251,7 +26251,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-68.1" title="local-type: typedef-68.1">local-type: typedef-68.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-21.1" title="local-type: typedef-21.1">local-type: typedef-21.1</a>
                       </em>
                     </p>
                   </td>
@@ -26984,7 +26984,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-68.1" title="local-type: typedef-68.1">local-type: typedef-68.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-21.1" title="local-type: typedef-21.1">local-type: typedef-21.1</a>
                       </em>
                     </p>
                   </td>
@@ -27797,7 +27797,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-82.2" title="local-type: typedef-82.2">local-type: typedef-82.2</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-76.2" title="local-type: typedef-76.2">local-type: typedef-76.2</a>
                       </em>
                     </p>
                   </td>
@@ -27828,7 +27828,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-82.3" title="local-type: typedef-82.3">local-type: typedef-82.3</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-76.3" title="local-type: typedef-76.3">local-type: typedef-76.3</a>
                       </em>
                     </p>
                   </td>
@@ -28077,7 +28077,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-73.1" title="local-type: typedef-73.1">local-type: typedef-73.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-80.1" title="local-type: typedef-80.1">local-type: typedef-80.1</a>
                       </em>
                     </p>
                   </td>
@@ -28139,7 +28139,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-73.2" title="local-type: typedef-73.2">local-type: typedef-73.2</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-80.2" title="local-type: typedef-80.2">local-type: typedef-80.2</a>
                       </em>
                     </p>
                   </td>
@@ -28439,7 +28439,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-82.4" title="local-type: typedef-82.4">local-type: typedef-82.4</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-76.4" title="local-type: typedef-76.4">local-type: typedef-76.4</a>
                       </em>
                     </p>
                   </td>
@@ -29176,8 +29176,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-70.3">
-          <h3>2.21. The complex type <code>element[siri:ServiceDelivery]#complexType (typedef-70.3)</code>
+        <div class="sect2" id="local-type.typedef-22.3">
+          <h3>2.21. The complex type <code>element[siri:ServiceDelivery]#complexType (typedef-22.3)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -29197,7 +29197,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-70.3)</code>
+                      <code>  (typedef-22.3)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -29441,7 +29441,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-68.1" title="local-type: typedef-68.1">local-type: typedef-68.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-21.1" title="local-type: typedef-21.1">local-type: typedef-21.1</a>
                       </em>
                     </p>
                   </td>
@@ -29502,8 +29502,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-68.1">
-          <h3>2.22. The complex type <code>group[siri:ServiceDeliveryRequestStatusGroup]/ErrorCondition#complexType (typedef-68.1)</code>
+        <div class="sect2" id="local-type.typedef-21.1">
+          <h3>2.22. The complex type <code>group[siri:ServiceDeliveryRequestStatusGroup]/ErrorCondition#complexType (typedef-21.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -29523,7 +29523,7 @@
                       <br/>
                       <code>  /ErrorCondition #complexType</code>
                       <br/>
-                      <code>  (typedef-68.1)</code>
+                      <code>  (typedef-21.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -29634,8 +29634,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-70.1">
-          <h3>2.23. The complex type <code>element[siri:ServiceRequest]#complexType (typedef-70.1)</code>
+        <div class="sect2" id="local-type.typedef-22.1">
+          <h3>2.23. The complex type <code>element[siri:ServiceRequest]#complexType (typedef-22.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -29655,7 +29655,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-70.1)</code>
+                      <code>  (typedef-22.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -29923,8 +29923,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-70.2">
-          <h3>2.24. The complex type <code>element[siri:SubscriptionRequest]#complexType (typedef-70.2)</code>
+        <div class="sect2" id="local-type.typedef-22.2">
+          <h3>2.24. The complex type <code>element[siri:SubscriptionRequest]#complexType (typedef-22.2)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -29944,7 +29944,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-70.2)</code>
+                      <code>  (typedef-22.2)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -30252,8 +30252,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-82.4">
-          <h3>2.25. The complex type <code>element[siri:ServiceDelivery]#complexType (typedef-82.4)</code>
+        <div class="sect2" id="local-type.typedef-76.4">
+          <h3>2.25. The complex type <code>element[siri:ServiceDelivery]#complexType (typedef-76.4)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -30273,7 +30273,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-82.4)</code>
+                      <code>  (typedef-76.4)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -30517,7 +30517,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-68.1" title="local-type: typedef-68.1">local-type: typedef-68.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-21.1" title="local-type: typedef-21.1">local-type: typedef-21.1</a>
                       </em>
                     </p>
                   </td>
@@ -30578,8 +30578,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-68.1">
-          <h3>2.26. The complex type <code>group[siri:ServiceDeliveryRequestStatusGroup]/ErrorCondition#complexType (typedef-68.1)</code>
+        <div class="sect2" id="local-type.typedef-21.1">
+          <h3>2.26. The complex type <code>group[siri:ServiceDeliveryRequestStatusGroup]/ErrorCondition#complexType (typedef-21.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -30599,7 +30599,7 @@
                       <br/>
                       <code>  /ErrorCondition #complexType</code>
                       <br/>
-                      <code>  (typedef-68.1)</code>
+                      <code>  (typedef-21.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -30710,8 +30710,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-82.2">
-          <h3>2.27. The complex type <code>element[siri:ServiceRequest]#complexType (typedef-82.2)</code>
+        <div class="sect2" id="local-type.typedef-76.2">
+          <h3>2.27. The complex type <code>element[siri:ServiceRequest]#complexType (typedef-76.2)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -30731,7 +30731,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-82.2)</code>
+                      <code>  (typedef-76.2)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -30965,8 +30965,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-82.3">
-          <h3>2.28. The complex type <code>element[siri:SubscriptionRequest]#complexType (typedef-82.3)</code>
+        <div class="sect2" id="local-type.typedef-76.3">
+          <h3>2.28. The complex type <code>element[siri:SubscriptionRequest]#complexType (typedef-76.3)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -30986,7 +30986,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-82.3)</code>
+                      <code>  (typedef-76.3)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -31294,8 +31294,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-82.4">
-          <h3>2.29. The complex type <code>element[siri:ServiceDelivery]#complexType (typedef-82.4)</code>
+        <div class="sect2" id="local-type.typedef-76.4">
+          <h3>2.29. The complex type <code>element[siri:ServiceDelivery]#complexType (typedef-76.4)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -31315,7 +31315,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-82.4)</code>
+                      <code>  (typedef-76.4)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -31559,7 +31559,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-68.1" title="local-type: typedef-68.1">local-type: typedef-68.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-21.1" title="local-type: typedef-21.1">local-type: typedef-21.1</a>
                       </em>
                     </p>
                   </td>
@@ -31620,8 +31620,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-68.1">
-          <h3>2.30. The complex type <code>group[siri:ServiceDeliveryRequestStatusGroup]/ErrorCondition#complexType (typedef-68.1)</code>
+        <div class="sect2" id="local-type.typedef-21.1">
+          <h3>2.30. The complex type <code>group[siri:ServiceDeliveryRequestStatusGroup]/ErrorCondition#complexType (typedef-21.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -31641,7 +31641,7 @@
                       <br/>
                       <code>  /ErrorCondition #complexType</code>
                       <br/>
-                      <code>  (typedef-68.1)</code>
+                      <code>  (typedef-21.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -31752,8 +31752,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-68.1">
-          <h3>2.31. The complex type <code>group[siri:ServiceDeliveryRequestStatusGroup]/ErrorCondition#complexType (typedef-68.1)</code>
+        <div class="sect2" id="local-type.typedef-21.1">
+          <h3>2.31. The complex type <code>group[siri:ServiceDeliveryRequestStatusGroup]/ErrorCondition#complexType (typedef-21.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -31773,7 +31773,7 @@
                       <br/>
                       <code>  /ErrorCondition #complexType</code>
                       <br/>
-                      <code>  (typedef-68.1)</code>
+                      <code>  (typedef-21.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -31884,8 +31884,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-82.2">
-          <h3>2.32. The complex type <code>element[siri:ServiceRequest]#complexType (typedef-82.2)</code>
+        <div class="sect2" id="local-type.typedef-76.2">
+          <h3>2.32. The complex type <code>element[siri:ServiceRequest]#complexType (typedef-76.2)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -31905,7 +31905,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-82.2)</code>
+                      <code>  (typedef-76.2)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -32139,8 +32139,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-82.3">
-          <h3>2.33. The complex type <code>element[siri:SubscriptionRequest]#complexType (typedef-82.3)</code>
+        <div class="sect2" id="local-type.typedef-76.3">
+          <h3>2.33. The complex type <code>element[siri:SubscriptionRequest]#complexType (typedef-76.3)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -32160,7 +32160,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-82.3)</code>
+                      <code>  (typedef-76.3)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -32468,8 +32468,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-68.1">
-          <h3>2.34. The complex type <code>group[siri:ServiceDeliveryRequestStatusGroup]/ErrorCondition#complexType (typedef-68.1)</code>
+        <div class="sect2" id="local-type.typedef-21.1">
+          <h3>2.34. The complex type <code>group[siri:ServiceDeliveryRequestStatusGroup]/ErrorCondition#complexType (typedef-21.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -32489,7 +32489,7 @@
                       <br/>
                       <code>  /ErrorCondition #complexType</code>
                       <br/>
-                      <code>  (typedef-68.1)</code>
+                      <code>  (typedef-21.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -32600,8 +32600,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-68.1">
-          <h3>2.35. The complex type <code>group[siri:ServiceDeliveryRequestStatusGroup]/ErrorCondition#complexType (typedef-68.1)</code>
+        <div class="sect2" id="local-type.typedef-21.1">
+          <h3>2.35. The complex type <code>group[siri:ServiceDeliveryRequestStatusGroup]/ErrorCondition#complexType (typedef-21.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -32621,7 +32621,7 @@
                       <br/>
                       <code>  /ErrorCondition #complexType</code>
                       <br/>
-                      <code>  (typedef-68.1)</code>
+                      <code>  (typedef-21.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -32732,8 +32732,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-82.2">
-          <h3>2.36. The complex type <code>element[siri:ServiceRequest]#complexType (typedef-82.2)</code>
+        <div class="sect2" id="local-type.typedef-76.2">
+          <h3>2.36. The complex type <code>element[siri:ServiceRequest]#complexType (typedef-76.2)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -32753,7 +32753,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-82.2)</code>
+                      <code>  (typedef-76.2)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -32987,8 +32987,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-82.3">
-          <h3>2.37. The complex type <code>element[siri:SubscriptionRequest]#complexType (typedef-82.3)</code>
+        <div class="sect2" id="local-type.typedef-76.3">
+          <h3>2.37. The complex type <code>element[siri:SubscriptionRequest]#complexType (typedef-76.3)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -33008,7 +33008,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-82.3)</code>
+                      <code>  (typedef-76.3)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -33316,8 +33316,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-73.1">
-          <h3>2.38. The complex type <code>element[siri:StopPointsRequest]#complexType (typedef-73.1)</code>
+        <div class="sect2" id="local-type.typedef-80.1">
+          <h3>2.38. The complex type <code>element[siri:StopPointsRequest]#complexType (typedef-80.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -33337,7 +33337,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-73.1)</code>
+                      <code>  (typedef-80.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -33727,8 +33727,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-73.2">
-          <h3>2.39. The complex type <code>element[siri:ServiceFeaturesRequest]#complexType (typedef-73.2)</code>
+        <div class="sect2" id="local-type.typedef-80.2">
+          <h3>2.39. The complex type <code>element[siri:ServiceFeaturesRequest]#complexType (typedef-80.2)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -33748,7 +33748,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-73.2)</code>
+                      <code>  (typedef-80.2)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -33966,8 +33966,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-82.4">
-          <h3>2.40. The complex type <code>element[siri:ServiceDelivery]#complexType (typedef-82.4)</code>
+        <div class="sect2" id="local-type.typedef-76.4">
+          <h3>2.40. The complex type <code>element[siri:ServiceDelivery]#complexType (typedef-76.4)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -33987,7 +33987,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-82.4)</code>
+                      <code>  (typedef-76.4)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -34231,7 +34231,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-68.1" title="local-type: typedef-68.1">local-type: typedef-68.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-21.1" title="local-type: typedef-21.1">local-type: typedef-21.1</a>
                       </em>
                     </p>
                   </td>
@@ -34292,8 +34292,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-68.1">
-          <h3>2.41. The complex type <code>group[siri:ServiceDeliveryRequestStatusGroup]/ErrorCondition#complexType (typedef-68.1)</code>
+        <div class="sect2" id="local-type.typedef-21.1">
+          <h3>2.41. The complex type <code>group[siri:ServiceDeliveryRequestStatusGroup]/ErrorCondition#complexType (typedef-21.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -34313,7 +34313,7 @@
                       <br/>
                       <code>  /ErrorCondition #complexType</code>
                       <br/>
-                      <code>  (typedef-68.1)</code>
+                      <code>  (typedef-21.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -35002,7 +35002,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-67.4" title="local-type: typedef-67.4">local-type: typedef-67.4</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-18.4" title="local-type: typedef-18.4">local-type: typedef-18.4</a>
                       </em>
                     </p>
                   </td>
@@ -35268,7 +35268,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-67.3" title="local-type: typedef-67.3">local-type: typedef-67.3</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-18.3" title="local-type: typedef-18.3">local-type: typedef-18.3</a>
                       </em>
                     </p>
                   </td>
@@ -37508,7 +37508,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-67.4" title="local-type: typedef-67.4">local-type: typedef-67.4</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-18.4" title="local-type: typedef-18.4">local-type: typedef-18.4</a>
                       </em>
                     </p>
                   </td>
@@ -37846,7 +37846,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-67.4" title="local-type: typedef-67.4">local-type: typedef-67.4</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-18.4" title="local-type: typedef-18.4">local-type: typedef-18.4</a>
                       </em>
                     </p>
                   </td>
@@ -38761,7 +38761,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-67.2" title="local-type: typedef-67.2">local-type: typedef-67.2</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-18.2" title="local-type: typedef-18.2">local-type: typedef-18.2</a>
                       </em>
                     </p>
                   </td>
@@ -38968,7 +38968,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-67.3" title="local-type: typedef-67.3">local-type: typedef-67.3</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-18.3" title="local-type: typedef-18.3">local-type: typedef-18.3</a>
                       </em>
                     </p>
                   </td>
@@ -39606,7 +39606,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-67.4" title="local-type: typedef-67.4">local-type: typedef-67.4</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-18.4" title="local-type: typedef-18.4">local-type: typedef-18.4</a>
                       </em>
                     </p>
                   </td>
@@ -42083,7 +42083,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-67.1" title="local-type: typedef-67.1">local-type: typedef-67.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-18.1" title="local-type: typedef-18.1">local-type: typedef-18.1</a>
                       </em>
                     </p>
                   </td>
@@ -42095,8 +42095,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-67.4">
-          <h3>3.56. The complex type <code>group[siri:CheckStatusPayloadGroup]/ErrorCondition#complexType (typedef-67.4)</code>
+        <div class="sect2" id="local-type.typedef-18.4">
+          <h3>3.56. The complex type <code>group[siri:CheckStatusPayloadGroup]/ErrorCondition#complexType (typedef-18.4)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -42116,7 +42116,7 @@
                       <br/>
                       <code>  /ErrorCondition #complexType</code>
                       <br/>
-                      <code>  (typedef-67.4)</code>
+                      <code>  (typedef-18.4)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -42227,8 +42227,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-67.3">
-          <h3>3.57. The complex type <code>group[siri:DataReceivedPayloadGroup]/ErrorCondition#complexType (typedef-67.3)</code>
+        <div class="sect2" id="local-type.typedef-18.3">
+          <h3>3.57. The complex type <code>group[siri:DataReceivedPayloadGroup]/ErrorCondition#complexType (typedef-18.3)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -42248,7 +42248,7 @@
                       <br/>
                       <code>  /ErrorCondition #complexType</code>
                       <br/>
-                      <code>  (typedef-67.3)</code>
+                      <code>  (typedef-18.3)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -42359,8 +42359,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-67.4">
-          <h3>3.58. The complex type <code>group[siri:CheckStatusPayloadGroup]/ErrorCondition#complexType (typedef-67.4)</code>
+        <div class="sect2" id="local-type.typedef-18.4">
+          <h3>3.58. The complex type <code>group[siri:CheckStatusPayloadGroup]/ErrorCondition#complexType (typedef-18.4)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -42380,7 +42380,7 @@
                       <br/>
                       <code>  /ErrorCondition #complexType</code>
                       <br/>
-                      <code>  (typedef-67.4)</code>
+                      <code>  (typedef-18.4)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -42491,8 +42491,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-67.4">
-          <h3>3.59. The complex type <code>group[siri:CheckStatusPayloadGroup]/ErrorCondition#complexType (typedef-67.4)</code>
+        <div class="sect2" id="local-type.typedef-18.4">
+          <h3>3.59. The complex type <code>group[siri:CheckStatusPayloadGroup]/ErrorCondition#complexType (typedef-18.4)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -42512,7 +42512,7 @@
                       <br/>
                       <code>  /ErrorCondition #complexType</code>
                       <br/>
-                      <code>  (typedef-67.4)</code>
+                      <code>  (typedef-18.4)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -42623,8 +42623,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-67.2">
-          <h3>3.60. The complex type <code>complexType[siri:DataReadyResponseStructure]/ErrorCondition#complexType (typedef-67.2)</code>
+        <div class="sect2" id="local-type.typedef-18.2">
+          <h3>3.60. The complex type <code>complexType[siri:DataReadyResponseStructure]/ErrorCondition#complexType (typedef-18.2)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -42644,7 +42644,7 @@
                       <br/>
                       <code>  /ErrorCondition #complexType</code>
                       <br/>
-                      <code>  (typedef-67.2)</code>
+                      <code>  (typedef-18.2)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -42755,8 +42755,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-67.3">
-          <h3>3.61. The complex type <code>group[siri:DataReceivedPayloadGroup]/ErrorCondition#complexType (typedef-67.3)</code>
+        <div class="sect2" id="local-type.typedef-18.3">
+          <h3>3.61. The complex type <code>group[siri:DataReceivedPayloadGroup]/ErrorCondition#complexType (typedef-18.3)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -42776,7 +42776,7 @@
                       <br/>
                       <code>  /ErrorCondition #complexType</code>
                       <br/>
-                      <code>  (typedef-67.3)</code>
+                      <code>  (typedef-18.3)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -42887,8 +42887,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-67.4">
-          <h3>3.62. The complex type <code>group[siri:CheckStatusPayloadGroup]/ErrorCondition#complexType (typedef-67.4)</code>
+        <div class="sect2" id="local-type.typedef-18.4">
+          <h3>3.62. The complex type <code>group[siri:CheckStatusPayloadGroup]/ErrorCondition#complexType (typedef-18.4)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -42908,7 +42908,7 @@
                       <br/>
                       <code>  /ErrorCondition #complexType</code>
                       <br/>
-                      <code>  (typedef-67.4)</code>
+                      <code>  (typedef-18.4)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -43019,8 +43019,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-67.1">
-          <h3>3.63. The complex type <code>complexType[siri:TerminationResponseStatusStructure]/ErrorCondition#complexType (typedef-67.1)</code>
+        <div class="sect2" id="local-type.typedef-18.1">
+          <h3>3.63. The complex type <code>complexType[siri:TerminationResponseStatusStructure]/ErrorCondition#complexType (typedef-18.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -43040,7 +43040,7 @@
                       <br/>
                       <code>  /ErrorCondition #complexType</code>
                       <br/>
-                      <code>  (typedef-67.1)</code>
+                      <code>  (typedef-18.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -50907,7 +50907,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-68.1" title="local-type: typedef-68.1">local-type: typedef-68.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-21.1" title="local-type: typedef-21.1">local-type: typedef-21.1</a>
                       </em>
                     </p>
                   </td>
@@ -53639,7 +53639,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-68.2" title="local-type: typedef-68.2">local-type: typedef-68.2</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-21.2" title="local-type: typedef-21.2">local-type: typedef-21.2</a>
                       </em>
                     </p>
                   </td>
@@ -53667,7 +53667,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-68.3" title="local-type: typedef-68.3">local-type: typedef-68.3</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-21.3" title="local-type: typedef-21.3">local-type: typedef-21.3</a>
                       </em>
                     </p>
                   </td>
@@ -55813,8 +55813,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-68.1">
-          <h3>6.64. The complex type <code>group[siri:ServiceDeliveryRequestStatusGroup]/ErrorCondition#complexType (typedef-68.1)</code>
+        <div class="sect2" id="local-type.typedef-21.1">
+          <h3>6.64. The complex type <code>group[siri:ServiceDeliveryRequestStatusGroup]/ErrorCondition#complexType (typedef-21.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -55834,7 +55834,7 @@
                       <br/>
                       <code>  /ErrorCondition #complexType</code>
                       <br/>
-                      <code>  (typedef-68.1)</code>
+                      <code>  (typedef-21.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -55945,8 +55945,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-68.2">
-          <h3>6.65. The complex type <code>complexType[siri:CapabilityGeneralInteractionStructure]/Interaction#complexType (typedef-68.2)</code>
+        <div class="sect2" id="local-type.typedef-21.2">
+          <h3>6.65. The complex type <code>complexType[siri:CapabilityGeneralInteractionStructure]/Interaction#complexType (typedef-21.2)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -55966,7 +55966,7 @@
                       <br/>
                       <code>  /Interaction #complexType</code>
                       <br/>
-                      <code>  (typedef-68.2)</code>
+                      <code>  (typedef-21.2)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -56034,8 +56034,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-68.3">
-          <h3>6.66. The complex type <code>complexType[siri:CapabilityGeneralInteractionStructure]/Delivery#complexType (typedef-68.3)</code>
+        <div class="sect2" id="local-type.typedef-21.3">
+          <h3>6.66. The complex type <code>complexType[siri:CapabilityGeneralInteractionStructure]/Delivery#complexType (typedef-21.3)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -56055,7 +56055,7 @@
                       <br/>
                       <code>  /Delivery #complexType</code>
                       <br/>
-                      <code>  (typedef-68.3)</code>
+                      <code>  (typedef-21.3)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -58412,7 +58412,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-72.3" title="local-type: typedef-72.3">local-type: typedef-72.3</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-77.3" title="local-type: typedef-77.3">local-type: typedef-77.3</a>
                       </em>
                     </p>
                   </td>
@@ -60094,7 +60094,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-72.1" title="local-type: typedef-72.1">local-type: typedef-72.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-77.1" title="local-type: typedef-77.1">local-type: typedef-77.1</a>
                       </em>
                     </p>
                   </td>
@@ -60118,7 +60118,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-72.2" title="local-type: typedef-72.2">local-type: typedef-72.2</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-77.2" title="local-type: typedef-77.2">local-type: typedef-77.2</a>
                       </em>
                     </p>
                   </td>
@@ -62394,8 +62394,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-72.3">
-          <h3>7.37. The complex type <code>element[siri:ConnectionMonitoringPermissions]#complexType (typedef-72.3)</code>
+        <div class="sect2" id="local-type.typedef-77.3">
+          <h3>7.37. The complex type <code>element[siri:ConnectionMonitoringPermissions]#complexType (typedef-77.3)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -62415,7 +62415,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-72.3)</code>
+                      <code>  (typedef-77.3)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -62453,8 +62453,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-72.3">
-          <h3>7.38. The complex type <code>element[siri:ConnectionMonitoringPermissions]#complexType (typedef-72.3)</code>
+        <div class="sect2" id="local-type.typedef-77.3">
+          <h3>7.38. The complex type <code>element[siri:ConnectionMonitoringPermissions]#complexType (typedef-77.3)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -62474,7 +62474,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-72.3)</code>
+                      <code>  (typedef-77.3)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -62512,8 +62512,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-72.1">
-          <h3>7.39. The complex type <code>complexType[siri:ConnectionMonitoringServiceCapabilitiesStructure]/TopicFiltering#complexType (typedef-72.1)</code>
+        <div class="sect2" id="local-type.typedef-77.1">
+          <h3>7.39. The complex type <code>complexType[siri:ConnectionMonitoringServiceCapabilitiesStructure]/TopicFiltering#complexType (typedef-77.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -62533,7 +62533,7 @@
                       <br/>
                       <code>  /TopicFiltering #complexType</code>
                       <br/>
-                      <code>  (typedef-72.1)</code>
+                      <code>  (typedef-77.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -62642,8 +62642,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-72.2">
-          <h3>7.40. The complex type <code>complexType[siri:ConnectionMonitoringServiceCapabilitiesStructure]/RequestPolicy#complexType (typedef-72.2)</code>
+        <div class="sect2" id="local-type.typedef-77.2">
+          <h3>7.40. The complex type <code>complexType[siri:ConnectionMonitoringServiceCapabilitiesStructure]/RequestPolicy#complexType (typedef-77.2)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -62663,7 +62663,7 @@
                       <br/>
                       <code>  /RequestPolicy #complexType</code>
                       <br/>
-                      <code>  (typedef-72.2)</code>
+                      <code>  (typedef-77.2)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -64289,7 +64289,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-84.1" title="local-type: typedef-84.1">local-type: typedef-84.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-85.1" title="local-type: typedef-85.1">local-type: typedef-85.1</a>
                       </em>
                     </p>
                   </td>
@@ -65412,7 +65412,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-84.2" title="local-type: typedef-84.2">local-type: typedef-84.2</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-85.2" title="local-type: typedef-85.2">local-type: typedef-85.2</a>
                       </em>
                     </p>
                   </td>
@@ -65436,7 +65436,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-84.3" title="local-type: typedef-84.3">local-type: typedef-84.3</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-85.3" title="local-type: typedef-85.3">local-type: typedef-85.3</a>
                       </em>
                     </p>
                   </td>
@@ -66652,8 +66652,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-84.1">
-          <h3>8.26. The complex type <code>complexType[siri:ConnectionTimetableCapabilitiesResponseStructure]/ConnectionTimetablePermissions#complexType (typedef-84.1)</code>
+        <div class="sect2" id="local-type.typedef-85.1">
+          <h3>8.26. The complex type <code>complexType[siri:ConnectionTimetableCapabilitiesResponseStructure]/ConnectionTimetablePermissions#complexType (typedef-85.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -66673,7 +66673,7 @@
                       <br/>
                       <code>  /ConnectionTimetablePermissions #complexType</code>
                       <br/>
-                      <code>  (typedef-84.1)</code>
+                      <code>  (typedef-85.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -66747,8 +66747,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-84.2">
-          <h3>8.27. The complex type <code>complexType[siri:ConnectionTimetableServiceCapabilitiesStructure]/TopicFiltering#complexType (typedef-84.2)</code>
+        <div class="sect2" id="local-type.typedef-85.2">
+          <h3>8.27. The complex type <code>complexType[siri:ConnectionTimetableServiceCapabilitiesStructure]/TopicFiltering#complexType (typedef-85.2)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -66768,7 +66768,7 @@
                       <br/>
                       <code>  /TopicFiltering #complexType</code>
                       <br/>
-                      <code>  (typedef-84.2)</code>
+                      <code>  (typedef-85.2)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -66838,8 +66838,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-84.3">
-          <h3>8.28. The complex type <code>complexType[siri:ConnectionTimetableServiceCapabilitiesStructure]/RequestPolicy#complexType (typedef-84.3)</code>
+        <div class="sect2" id="local-type.typedef-85.3">
+          <h3>8.28. The complex type <code>complexType[siri:ConnectionTimetableServiceCapabilitiesStructure]/RequestPolicy#complexType (typedef-85.3)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -66859,7 +66859,7 @@
                       <br/>
                       <code>  /RequestPolicy #complexType</code>
                       <br/>
-                      <code>  (typedef-84.3)</code>
+                      <code>  (typedef-85.3)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -68306,7 +68306,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-79.2" title="local-type: typedef-79.2">local-type: typedef-79.2</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-74.2" title="local-type: typedef-74.2">local-type: typedef-74.2</a>
                       </em>
                     </p>
                   </td>
@@ -68327,7 +68327,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-79.3" title="local-type: typedef-79.3">local-type: typedef-79.3</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-74.3" title="local-type: typedef-74.3">local-type: typedef-74.3</a>
                       </em>
                     </p>
                   </td>
@@ -68348,7 +68348,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-79.7" title="local-type: typedef-79.7">local-type: typedef-79.7</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-74.7" title="local-type: typedef-74.7">local-type: typedef-74.7</a>
                       </em>
                     </p>
                   </td>
@@ -68369,7 +68369,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-79.9" title="local-type: typedef-79.9">local-type: typedef-79.9</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-74.9" title="local-type: typedef-74.9">local-type: typedef-74.9</a>
                       </em>
                     </p>
                   </td>
@@ -68390,7 +68390,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-79.10" title="local-type: typedef-79.10">local-type: typedef-79.10</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-74.10" title="local-type: typedef-74.10">local-type: typedef-74.10</a>
                       </em>
                     </p>
                   </td>
@@ -68756,7 +68756,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-79.1" title="local-type: typedef-79.1">local-type: typedef-79.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-74.1" title="local-type: typedef-74.1">local-type: typedef-74.1</a>
                       </em>
                     </p>
                   </td>
@@ -70232,7 +70232,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-79.18" title="local-type: typedef-79.18">local-type: typedef-79.18</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-74.18" title="local-type: typedef-74.18">local-type: typedef-74.18</a>
                       </em>
                     </p>
                   </td>
@@ -70262,7 +70262,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-79.19" title="local-type: typedef-79.19">local-type: typedef-79.19</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-74.19" title="local-type: typedef-74.19">local-type: typedef-74.19</a>
                       </em>
                     </p>
                   </td>
@@ -70391,7 +70391,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-79.18" title="local-type: typedef-79.18">local-type: typedef-79.18</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-74.18" title="local-type: typedef-74.18">local-type: typedef-74.18</a>
                       </em>
                     </p>
                   </td>
@@ -70421,7 +70421,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-79.19" title="local-type: typedef-79.19">local-type: typedef-79.19</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-74.19" title="local-type: typedef-74.19">local-type: typedef-74.19</a>
                       </em>
                     </p>
                   </td>
@@ -72252,7 +72252,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-79.18" title="local-type: typedef-79.18">local-type: typedef-79.18</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-74.18" title="local-type: typedef-74.18">local-type: typedef-74.18</a>
                       </em>
                     </p>
                   </td>
@@ -72282,7 +72282,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-79.19" title="local-type: typedef-79.19">local-type: typedef-79.19</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-74.19" title="local-type: typedef-74.19">local-type: typedef-74.19</a>
                       </em>
                     </p>
                   </td>
@@ -73014,7 +73014,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-79.14" title="local-type: typedef-79.14">local-type: typedef-79.14</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-74.14" title="local-type: typedef-74.14">local-type: typedef-74.14</a>
                       </em>
                     </p>
                   </td>
@@ -73713,7 +73713,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-79.2" title="local-type: typedef-79.2">local-type: typedef-79.2</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-74.2" title="local-type: typedef-74.2">local-type: typedef-74.2</a>
                       </em>
                     </p>
                   </td>
@@ -73734,7 +73734,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-79.3" title="local-type: typedef-79.3">local-type: typedef-79.3</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-74.3" title="local-type: typedef-74.3">local-type: typedef-74.3</a>
                       </em>
                     </p>
                   </td>
@@ -73755,7 +73755,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-79.7" title="local-type: typedef-79.7">local-type: typedef-79.7</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-74.7" title="local-type: typedef-74.7">local-type: typedef-74.7</a>
                       </em>
                     </p>
                   </td>
@@ -73776,7 +73776,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-79.9" title="local-type: typedef-79.9">local-type: typedef-79.9</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-74.9" title="local-type: typedef-74.9">local-type: typedef-74.9</a>
                       </em>
                     </p>
                   </td>
@@ -73797,7 +73797,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-79.10" title="local-type: typedef-79.10">local-type: typedef-79.10</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-74.10" title="local-type: typedef-74.10">local-type: typedef-74.10</a>
                       </em>
                     </p>
                   </td>
@@ -74043,7 +74043,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-79.1" title="local-type: typedef-79.1">local-type: typedef-79.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-74.1" title="local-type: typedef-74.1">local-type: typedef-74.1</a>
                       </em>
                     </p>
                   </td>
@@ -74718,7 +74718,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-79.1" title="local-type: typedef-79.1">local-type: typedef-79.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-74.1" title="local-type: typedef-74.1">local-type: typedef-74.1</a>
                       </em>
                     </p>
                   </td>
@@ -74982,7 +74982,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-79.11" title="local-type: typedef-79.11">local-type: typedef-79.11</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-74.11" title="local-type: typedef-74.11">local-type: typedef-74.11</a>
                       </em>
                     </p>
                   </td>
@@ -75006,7 +75006,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-79.12" title="local-type: typedef-79.12">local-type: typedef-79.12</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-74.12" title="local-type: typedef-74.12">local-type: typedef-74.12</a>
                       </em>
                     </p>
                   </td>
@@ -75078,7 +75078,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-79.13" title="local-type: typedef-79.13">local-type: typedef-79.13</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-74.13" title="local-type: typedef-74.13">local-type: typedef-74.13</a>
                       </em>
                     </p>
                   </td>
@@ -75212,7 +75212,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-61.1" title="local-type: typedef-61.1">local-type: typedef-61.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-44.1" title="local-type: typedef-44.1">local-type: typedef-44.1</a>
                       </em>
                     </p>
                   </td>
@@ -75246,7 +75246,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-2.2" title="local-type: typedef-2.2">local-type: typedef-2.2</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-65.2" title="local-type: typedef-65.2">local-type: typedef-65.2</a>
                       </em>
                     </p>
                   </td>
@@ -75275,7 +75275,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-2.1" title="local-type: typedef-2.1">local-type: typedef-2.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-65.1" title="local-type: typedef-65.1">local-type: typedef-65.1</a>
                       </em>
                     </p>
                   </td>
@@ -76023,7 +76023,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-79.15" title="local-type: typedef-79.15">local-type: typedef-79.15</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-74.15" title="local-type: typedef-74.15">local-type: typedef-74.15</a>
                       </em>
                     </p>
                   </td>
@@ -76866,7 +76866,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-79.16" title="local-type: typedef-79.16">local-type: typedef-79.16</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-74.16" title="local-type: typedef-74.16">local-type: typedef-74.16</a>
                       </em>
                     </p>
                   </td>
@@ -76995,7 +76995,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-79.17" title="local-type: typedef-79.17">local-type: typedef-79.17</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-74.17" title="local-type: typedef-74.17">local-type: typedef-74.17</a>
                       </em>
                     </p>
                   </td>
@@ -80377,8 +80377,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-79.14">
-          <h3>9.83. The complex type <code>element[siri:ControlActionPermissions]#complexType (typedef-79.14)</code>
+        <div class="sect2" id="local-type.typedef-74.14">
+          <h3>9.83. The complex type <code>element[siri:ControlActionPermissions]#complexType (typedef-74.14)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -80398,7 +80398,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-79.14)</code>
+                      <code>  (typedef-74.14)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -80472,8 +80472,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-79.2">
-          <h3>9.84. The complex type <code>group[siri:ControlActionPayloadGroup]/controlActions#complexType (typedef-79.2)</code>
+        <div class="sect2" id="local-type.typedef-74.2">
+          <h3>9.84. The complex type <code>group[siri:ControlActionPayloadGroup]/controlActions#complexType (typedef-74.2)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -80493,7 +80493,7 @@
                       <br/>
                       <code>  /controlActions #complexType</code>
                       <br/>
-                      <code>  (typedef-79.2)</code>
+                      <code>  (typedef-74.2)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -80535,8 +80535,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-79.3">
-          <h3>9.85. The complex type <code>group[siri:ControlActionPayloadGroup]/groupsOfControlActions#complexType (typedef-79.3)</code>
+        <div class="sect2" id="local-type.typedef-74.3">
+          <h3>9.85. The complex type <code>group[siri:ControlActionPayloadGroup]/groupsOfControlActions#complexType (typedef-74.3)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -80556,7 +80556,7 @@
                       <br/>
                       <code>  /groupsOfControlActions #complexType</code>
                       <br/>
-                      <code>  (typedef-79.3)</code>
+                      <code>  (typedef-74.3)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -80586,7 +80586,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-79.4" title="local-type: typedef-79.4">local-type: typedef-79.4</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-74.4" title="local-type: typedef-74.4">local-type: typedef-74.4</a>
                       </em>
                     </p>
                   </td>
@@ -80598,8 +80598,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-79.4">
-          <h3>9.86. The complex type <code>group[siri:ControlActionPayloadGroup]/groupsOfControlActions/GroupOfControlActions#complexType (typedef-79.4)</code>
+        <div class="sect2" id="local-type.typedef-74.4">
+          <h3>9.86. The complex type <code>group[siri:ControlActionPayloadGroup]/groupsOfControlActions/GroupOfControlActions#complexType (typedef-74.4)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -80619,7 +80619,7 @@
                       <br/>
                       <code>  /groupsOfControlActions/GroupOfControlActions #complexType</code>
                       <br/>
-                      <code>  (typedef-79.4)</code>
+                      <code>  (typedef-74.4)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -80789,7 +80789,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-79.5" title="local-type: typedef-79.5">local-type: typedef-79.5</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-74.5" title="local-type: typedef-74.5">local-type: typedef-74.5</a>
                       </em>
                     </p>
                   </td>
@@ -80813,7 +80813,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-79.6" title="local-type: typedef-79.6">local-type: typedef-79.6</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-74.6" title="local-type: typedef-74.6">local-type: typedef-74.6</a>
                       </em>
                     </p>
                   </td>
@@ -80825,8 +80825,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-79.5">
-          <h3>9.87. The complex type <code>group[siri:ControlActionPayloadGroup]/groupsOfControlActions/GroupOfControlActions/AddedControlActions#complexType (typedef-79.5)</code>
+        <div class="sect2" id="local-type.typedef-74.5">
+          <h3>9.87. The complex type <code>group[siri:ControlActionPayloadGroup]/groupsOfControlActions/GroupOfControlActions/AddedControlActions#complexType (typedef-74.5)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -80846,7 +80846,7 @@
                       <br/>
                       <code>  /groupsOfControlActions/GroupOfControlActions/AddedControlActions #complexType</code>
                       <br/>
-                      <code>  (typedef-79.5)</code>
+                      <code>  (typedef-74.5)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -80888,8 +80888,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-79.6">
-          <h3>9.88. The complex type <code>group[siri:ControlActionPayloadGroup]/groupsOfControlActions/GroupOfControlActions/RemovedControlActions#complexType (typedef-79.6)</code>
+        <div class="sect2" id="local-type.typedef-74.6">
+          <h3>9.88. The complex type <code>group[siri:ControlActionPayloadGroup]/groupsOfControlActions/GroupOfControlActions/RemovedControlActions#complexType (typedef-74.6)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -80909,7 +80909,7 @@
                       <br/>
                       <code>  /groupsOfControlActions/GroupOfControlActions/RemovedControlActions #complexType</code>
                       <br/>
-                      <code>  (typedef-79.6)</code>
+                      <code>  (typedef-74.6)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -80951,8 +80951,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-79.7">
-          <h3>9.89. The complex type <code>group[siri:ControlActionPayloadGroup]/revokedControlActions#complexType (typedef-79.7)</code>
+        <div class="sect2" id="local-type.typedef-74.7">
+          <h3>9.89. The complex type <code>group[siri:ControlActionPayloadGroup]/revokedControlActions#complexType (typedef-74.7)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -80972,7 +80972,7 @@
                       <br/>
                       <code>  /revokedControlActions #complexType</code>
                       <br/>
-                      <code>  (typedef-79.7)</code>
+                      <code>  (typedef-74.7)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -81002,7 +81002,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-79.8" title="local-type: typedef-79.8">local-type: typedef-79.8</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-74.8" title="local-type: typedef-74.8">local-type: typedef-74.8</a>
                       </em>
                     </p>
                   </td>
@@ -81014,8 +81014,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-79.8">
-          <h3>9.90. The complex type <code>group[siri:ControlActionPayloadGroup]/revokedControlActions/RevokedControlAction#complexType (typedef-79.8)</code>
+        <div class="sect2" id="local-type.typedef-74.8">
+          <h3>9.90. The complex type <code>group[siri:ControlActionPayloadGroup]/revokedControlActions/RevokedControlAction#complexType (typedef-74.8)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -81035,7 +81035,7 @@
                       <br/>
                       <code>  /revokedControlActions/RevokedControlAction #complexType</code>
                       <br/>
-                      <code>  (typedef-79.8)</code>
+                      <code>  (typedef-74.8)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -81168,8 +81168,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-79.9">
-          <h3>9.91. The complex type <code>group[siri:ControlActionPayloadGroup]/driverMessages#complexType (typedef-79.9)</code>
+        <div class="sect2" id="local-type.typedef-74.9">
+          <h3>9.91. The complex type <code>group[siri:ControlActionPayloadGroup]/driverMessages#complexType (typedef-74.9)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -81189,7 +81189,7 @@
                       <br/>
                       <code>  /driverMessages #complexType</code>
                       <br/>
-                      <code>  (typedef-79.9)</code>
+                      <code>  (typedef-74.9)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -81231,8 +81231,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-79.10">
-          <h3>9.92. The complex type <code>group[siri:ControlActionPayloadGroup]/vehicleDetectings#complexType (typedef-79.10)</code>
+        <div class="sect2" id="local-type.typedef-74.10">
+          <h3>9.92. The complex type <code>group[siri:ControlActionPayloadGroup]/vehicleDetectings#complexType (typedef-74.10)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -81252,7 +81252,7 @@
                       <br/>
                       <code>  /vehicleDetectings #complexType</code>
                       <br/>
-                      <code>  (typedef-79.10)</code>
+                      <code>  (typedef-74.10)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -81294,8 +81294,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-79.1">
-          <h3>9.93. The complex type <code>group[siri:ControlActionTopicGroup]/Lines#complexType (typedef-79.1)</code>
+        <div class="sect2" id="local-type.typedef-74.1">
+          <h3>9.93. The complex type <code>group[siri:ControlActionTopicGroup]/Lines#complexType (typedef-74.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -81315,7 +81315,7 @@
                       <br/>
                       <code>  /Lines #complexType</code>
                       <br/>
-                      <code>  (typedef-79.1)</code>
+                      <code>  (typedef-74.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -81357,8 +81357,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-79.18">
-          <h3>9.94. The complex type <code>group[siri:PartOfJourneyPatternScope]/SelectedCalls#complexType (typedef-79.18)</code>
+        <div class="sect2" id="local-type.typedef-74.18">
+          <h3>9.94. The complex type <code>group[siri:PartOfJourneyPatternScope]/SelectedCalls#complexType (typedef-74.18)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -81378,7 +81378,7 @@
                       <br/>
                       <code>  /SelectedCalls #complexType</code>
                       <br/>
-                      <code>  (typedef-79.18)</code>
+                      <code>  (typedef-74.18)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -81420,8 +81420,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-79.19">
-          <h3>9.95. The complex type <code>group[siri:PartOfJourneyPatternScope]/CallsBetweenPoints#complexType (typedef-79.19)</code>
+        <div class="sect2" id="local-type.typedef-74.19">
+          <h3>9.95. The complex type <code>group[siri:PartOfJourneyPatternScope]/CallsBetweenPoints#complexType (typedef-74.19)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -81441,7 +81441,7 @@
                       <br/>
                       <code>  /CallsBetweenPoints #complexType</code>
                       <br/>
-                      <code>  (typedef-79.19)</code>
+                      <code>  (typedef-74.19)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -81511,8 +81511,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-79.18">
-          <h3>9.96. The complex type <code>group[siri:PartOfJourneyPatternScope]/SelectedCalls#complexType (typedef-79.18)</code>
+        <div class="sect2" id="local-type.typedef-74.18">
+          <h3>9.96. The complex type <code>group[siri:PartOfJourneyPatternScope]/SelectedCalls#complexType (typedef-74.18)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -81532,7 +81532,7 @@
                       <br/>
                       <code>  /SelectedCalls #complexType</code>
                       <br/>
-                      <code>  (typedef-79.18)</code>
+                      <code>  (typedef-74.18)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -81574,8 +81574,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-79.19">
-          <h3>9.97. The complex type <code>group[siri:PartOfJourneyPatternScope]/CallsBetweenPoints#complexType (typedef-79.19)</code>
+        <div class="sect2" id="local-type.typedef-74.19">
+          <h3>9.97. The complex type <code>group[siri:PartOfJourneyPatternScope]/CallsBetweenPoints#complexType (typedef-74.19)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -81595,7 +81595,7 @@
                       <br/>
                       <code>  /CallsBetweenPoints #complexType</code>
                       <br/>
-                      <code>  (typedef-79.19)</code>
+                      <code>  (typedef-74.19)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -81665,8 +81665,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-79.18">
-          <h3>9.98. The complex type <code>group[siri:PartOfJourneyPatternScope]/SelectedCalls#complexType (typedef-79.18)</code>
+        <div class="sect2" id="local-type.typedef-74.18">
+          <h3>9.98. The complex type <code>group[siri:PartOfJourneyPatternScope]/SelectedCalls#complexType (typedef-74.18)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -81686,7 +81686,7 @@
                       <br/>
                       <code>  /SelectedCalls #complexType</code>
                       <br/>
-                      <code>  (typedef-79.18)</code>
+                      <code>  (typedef-74.18)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -81728,8 +81728,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-79.19">
-          <h3>9.99. The complex type <code>group[siri:PartOfJourneyPatternScope]/CallsBetweenPoints#complexType (typedef-79.19)</code>
+        <div class="sect2" id="local-type.typedef-74.19">
+          <h3>9.99. The complex type <code>group[siri:PartOfJourneyPatternScope]/CallsBetweenPoints#complexType (typedef-74.19)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -81749,7 +81749,7 @@
                       <br/>
                       <code>  /CallsBetweenPoints #complexType</code>
                       <br/>
-                      <code>  (typedef-79.19)</code>
+                      <code>  (typedef-74.19)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -81819,8 +81819,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-79.14">
-          <h3>9.100. The complex type <code>element[siri:ControlActionPermissions]#complexType (typedef-79.14)</code>
+        <div class="sect2" id="local-type.typedef-74.14">
+          <h3>9.100. The complex type <code>element[siri:ControlActionPermissions]#complexType (typedef-74.14)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -81840,7 +81840,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-79.14)</code>
+                      <code>  (typedef-74.14)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -81914,8 +81914,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-79.2">
-          <h3>9.101. The complex type <code>group[siri:ControlActionPayloadGroup]/controlActions#complexType (typedef-79.2)</code>
+        <div class="sect2" id="local-type.typedef-74.2">
+          <h3>9.101. The complex type <code>group[siri:ControlActionPayloadGroup]/controlActions#complexType (typedef-74.2)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -81935,7 +81935,7 @@
                       <br/>
                       <code>  /controlActions #complexType</code>
                       <br/>
-                      <code>  (typedef-79.2)</code>
+                      <code>  (typedef-74.2)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -81977,8 +81977,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-79.3">
-          <h3>9.102. The complex type <code>group[siri:ControlActionPayloadGroup]/groupsOfControlActions#complexType (typedef-79.3)</code>
+        <div class="sect2" id="local-type.typedef-74.3">
+          <h3>9.102. The complex type <code>group[siri:ControlActionPayloadGroup]/groupsOfControlActions#complexType (typedef-74.3)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -81998,7 +81998,7 @@
                       <br/>
                       <code>  /groupsOfControlActions #complexType</code>
                       <br/>
-                      <code>  (typedef-79.3)</code>
+                      <code>  (typedef-74.3)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -82028,7 +82028,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-79.4" title="local-type: typedef-79.4">local-type: typedef-79.4</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-74.4" title="local-type: typedef-74.4">local-type: typedef-74.4</a>
                       </em>
                     </p>
                   </td>
@@ -82040,8 +82040,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-79.4">
-          <h3>9.103. The complex type <code>group[siri:ControlActionPayloadGroup]/groupsOfControlActions/GroupOfControlActions#complexType (typedef-79.4)</code>
+        <div class="sect2" id="local-type.typedef-74.4">
+          <h3>9.103. The complex type <code>group[siri:ControlActionPayloadGroup]/groupsOfControlActions/GroupOfControlActions#complexType (typedef-74.4)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -82061,7 +82061,7 @@
                       <br/>
                       <code>  /groupsOfControlActions/GroupOfControlActions #complexType</code>
                       <br/>
-                      <code>  (typedef-79.4)</code>
+                      <code>  (typedef-74.4)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -82231,7 +82231,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-79.5" title="local-type: typedef-79.5">local-type: typedef-79.5</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-74.5" title="local-type: typedef-74.5">local-type: typedef-74.5</a>
                       </em>
                     </p>
                   </td>
@@ -82255,7 +82255,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-79.6" title="local-type: typedef-79.6">local-type: typedef-79.6</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-74.6" title="local-type: typedef-74.6">local-type: typedef-74.6</a>
                       </em>
                     </p>
                   </td>
@@ -82267,8 +82267,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-79.5">
-          <h3>9.104. The complex type <code>group[siri:ControlActionPayloadGroup]/groupsOfControlActions/GroupOfControlActions/AddedControlActions#complexType (typedef-79.5)</code>
+        <div class="sect2" id="local-type.typedef-74.5">
+          <h3>9.104. The complex type <code>group[siri:ControlActionPayloadGroup]/groupsOfControlActions/GroupOfControlActions/AddedControlActions#complexType (typedef-74.5)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -82288,7 +82288,7 @@
                       <br/>
                       <code>  /groupsOfControlActions/GroupOfControlActions/AddedControlActions #complexType</code>
                       <br/>
-                      <code>  (typedef-79.5)</code>
+                      <code>  (typedef-74.5)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -82330,8 +82330,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-79.6">
-          <h3>9.105. The complex type <code>group[siri:ControlActionPayloadGroup]/groupsOfControlActions/GroupOfControlActions/RemovedControlActions#complexType (typedef-79.6)</code>
+        <div class="sect2" id="local-type.typedef-74.6">
+          <h3>9.105. The complex type <code>group[siri:ControlActionPayloadGroup]/groupsOfControlActions/GroupOfControlActions/RemovedControlActions#complexType (typedef-74.6)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -82351,7 +82351,7 @@
                       <br/>
                       <code>  /groupsOfControlActions/GroupOfControlActions/RemovedControlActions #complexType</code>
                       <br/>
-                      <code>  (typedef-79.6)</code>
+                      <code>  (typedef-74.6)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -82393,8 +82393,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-79.7">
-          <h3>9.106. The complex type <code>group[siri:ControlActionPayloadGroup]/revokedControlActions#complexType (typedef-79.7)</code>
+        <div class="sect2" id="local-type.typedef-74.7">
+          <h3>9.106. The complex type <code>group[siri:ControlActionPayloadGroup]/revokedControlActions#complexType (typedef-74.7)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -82414,7 +82414,7 @@
                       <br/>
                       <code>  /revokedControlActions #complexType</code>
                       <br/>
-                      <code>  (typedef-79.7)</code>
+                      <code>  (typedef-74.7)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -82444,7 +82444,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-79.8" title="local-type: typedef-79.8">local-type: typedef-79.8</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-74.8" title="local-type: typedef-74.8">local-type: typedef-74.8</a>
                       </em>
                     </p>
                   </td>
@@ -82456,8 +82456,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-79.8">
-          <h3>9.107. The complex type <code>group[siri:ControlActionPayloadGroup]/revokedControlActions/RevokedControlAction#complexType (typedef-79.8)</code>
+        <div class="sect2" id="local-type.typedef-74.8">
+          <h3>9.107. The complex type <code>group[siri:ControlActionPayloadGroup]/revokedControlActions/RevokedControlAction#complexType (typedef-74.8)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -82477,7 +82477,7 @@
                       <br/>
                       <code>  /revokedControlActions/RevokedControlAction #complexType</code>
                       <br/>
-                      <code>  (typedef-79.8)</code>
+                      <code>  (typedef-74.8)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -82610,8 +82610,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-79.9">
-          <h3>9.108. The complex type <code>group[siri:ControlActionPayloadGroup]/driverMessages#complexType (typedef-79.9)</code>
+        <div class="sect2" id="local-type.typedef-74.9">
+          <h3>9.108. The complex type <code>group[siri:ControlActionPayloadGroup]/driverMessages#complexType (typedef-74.9)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -82631,7 +82631,7 @@
                       <br/>
                       <code>  /driverMessages #complexType</code>
                       <br/>
-                      <code>  (typedef-79.9)</code>
+                      <code>  (typedef-74.9)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -82673,8 +82673,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-79.10">
-          <h3>9.109. The complex type <code>group[siri:ControlActionPayloadGroup]/vehicleDetectings#complexType (typedef-79.10)</code>
+        <div class="sect2" id="local-type.typedef-74.10">
+          <h3>9.109. The complex type <code>group[siri:ControlActionPayloadGroup]/vehicleDetectings#complexType (typedef-74.10)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -82694,7 +82694,7 @@
                       <br/>
                       <code>  /vehicleDetectings #complexType</code>
                       <br/>
-                      <code>  (typedef-79.10)</code>
+                      <code>  (typedef-74.10)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -82736,8 +82736,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-79.1">
-          <h3>9.110. The complex type <code>group[siri:ControlActionTopicGroup]/Lines#complexType (typedef-79.1)</code>
+        <div class="sect2" id="local-type.typedef-74.1">
+          <h3>9.110. The complex type <code>group[siri:ControlActionTopicGroup]/Lines#complexType (typedef-74.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -82757,7 +82757,7 @@
                       <br/>
                       <code>  /Lines #complexType</code>
                       <br/>
-                      <code>  (typedef-79.1)</code>
+                      <code>  (typedef-74.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -82799,8 +82799,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-79.1">
-          <h3>9.111. The complex type <code>group[siri:ControlActionTopicGroup]/Lines#complexType (typedef-79.1)</code>
+        <div class="sect2" id="local-type.typedef-74.1">
+          <h3>9.111. The complex type <code>group[siri:ControlActionTopicGroup]/Lines#complexType (typedef-74.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -82820,7 +82820,7 @@
                       <br/>
                       <code>  /Lines #complexType</code>
                       <br/>
-                      <code>  (typedef-79.1)</code>
+                      <code>  (typedef-74.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -82862,8 +82862,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-79.11">
-          <h3>9.112. The complex type <code>complexType[siri:ControlActionServiceCapabilitiesStructure]/TopicFiltering#complexType (typedef-79.11)</code>
+        <div class="sect2" id="local-type.typedef-74.11">
+          <h3>9.112. The complex type <code>complexType[siri:ControlActionServiceCapabilitiesStructure]/TopicFiltering#complexType (typedef-74.11)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -82883,7 +82883,7 @@
                       <br/>
                       <code>  /TopicFiltering #complexType</code>
                       <br/>
-                      <code>  (typedef-79.11)</code>
+                      <code>  (typedef-74.11)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -83015,8 +83015,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-79.12">
-          <h3>9.113. The complex type <code>complexType[siri:ControlActionServiceCapabilitiesStructure]/RequestPolicy#complexType (typedef-79.12)</code>
+        <div class="sect2" id="local-type.typedef-74.12">
+          <h3>9.113. The complex type <code>complexType[siri:ControlActionServiceCapabilitiesStructure]/RequestPolicy#complexType (typedef-74.12)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -83036,7 +83036,7 @@
                       <br/>
                       <code>  /RequestPolicy #complexType</code>
                       <br/>
-                      <code>  (typedef-79.12)</code>
+                      <code>  (typedef-74.12)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -83254,8 +83254,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-79.13">
-          <h3>9.114. The complex type <code>complexType[siri:ControlActionServiceCapabilitiesStructure]/ResponseFeatures#complexType (typedef-79.13)</code>
+        <div class="sect2" id="local-type.typedef-74.13">
+          <h3>9.114. The complex type <code>complexType[siri:ControlActionServiceCapabilitiesStructure]/ResponseFeatures#complexType (typedef-74.13)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -83275,7 +83275,7 @@
                       <br/>
                       <code>  /ResponseFeatures #complexType</code>
                       <br/>
-                      <code>  (typedef-79.13)</code>
+                      <code>  (typedef-74.13)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -83312,8 +83312,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-61.1">
-          <h3>9.115. The complex type <code>complexType[siri:AbstractPermissionStructure]/GeneralCapabilities#complexType (typedef-61.1)</code>
+        <div class="sect2" id="local-type.typedef-44.1">
+          <h3>9.115. The complex type <code>complexType[siri:AbstractPermissionStructure]/GeneralCapabilities#complexType (typedef-44.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -83333,7 +83333,7 @@
                       <br/>
                       <code>  /GeneralCapabilities #complexType</code>
                       <br/>
-                      <code>  (typedef-61.1)</code>
+                      <code>  (typedef-44.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -83401,8 +83401,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-2.2">
-          <h3>9.116. The complex type <code>element[siri:OperatorPermissions]#complexType (typedef-2.2)</code>
+        <div class="sect2" id="local-type.typedef-65.2">
+          <h3>9.116. The complex type <code>element[siri:OperatorPermissions]#complexType (typedef-65.2)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -83422,7 +83422,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-2.2)</code>
+                      <code>  (typedef-65.2)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -83507,8 +83507,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-2.1">
-          <h3>9.117. The complex type <code>element[siri:LinePermissions]#complexType (typedef-2.1)</code>
+        <div class="sect2" id="local-type.typedef-65.1">
+          <h3>9.117. The complex type <code>element[siri:LinePermissions]#complexType (typedef-65.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -83528,7 +83528,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-2.1)</code>
+                      <code>  (typedef-65.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -83613,8 +83613,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-79.15">
-          <h3>9.118. The complex type <code>complexType[siri:ControlActionStructure]/SituationDescription#complexType (typedef-79.15)</code>
+        <div class="sect2" id="local-type.typedef-74.15">
+          <h3>9.118. The complex type <code>complexType[siri:ControlActionStructure]/SituationDescription#complexType (typedef-74.15)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -83634,7 +83634,7 @@
                       <br/>
                       <code>  /SituationDescription #complexType</code>
                       <br/>
-                      <code>  (typedef-79.15)</code>
+                      <code>  (typedef-74.15)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -83785,7 +83785,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-11.14" title="local-type: typedef-11.14">local-type: typedef-11.14</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-64.14" title="local-type: typedef-64.14">local-type: typedef-64.14</a>
                       </em>
                     </p>
                   </td>
@@ -83806,7 +83806,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-11.16" title="local-type: typedef-11.16">local-type: typedef-11.16</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-64.16" title="local-type: typedef-64.16">local-type: typedef-64.16</a>
                       </em>
                     </p>
                   </td>
@@ -83818,8 +83818,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-11.14">
-          <h3>9.119. The complex type <code>group[siri:DescriptionGroup]/Images#complexType (typedef-11.14)</code>
+        <div class="sect2" id="local-type.typedef-64.14">
+          <h3>9.119. The complex type <code>group[siri:DescriptionGroup]/Images#complexType (typedef-64.14)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -83839,7 +83839,7 @@
                       <br/>
                       <code>  /Images #complexType</code>
                       <br/>
-                      <code>  (typedef-11.14)</code>
+                      <code>  (typedef-64.14)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -83869,7 +83869,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-11.15" title="local-type: typedef-11.15">local-type: typedef-11.15</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-64.15" title="local-type: typedef-64.15">local-type: typedef-64.15</a>
                       </em>
                     </p>
                   </td>
@@ -83881,8 +83881,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-11.15">
-          <h3>9.120. The complex type <code>group[siri:DescriptionGroup]/Images/Image#complexType (typedef-11.15)</code>
+        <div class="sect2" id="local-type.typedef-64.15">
+          <h3>9.120. The complex type <code>group[siri:DescriptionGroup]/Images/Image#complexType (typedef-64.15)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -83902,7 +83902,7 @@
                       <br/>
                       <code>  /Images/Image #complexType</code>
                       <br/>
-                      <code>  (typedef-11.15)</code>
+                      <code>  (typedef-64.15)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -84017,8 +84017,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-11.16">
-          <h3>9.121. The complex type <code>group[siri:DescriptionGroup]/InfoLinks#complexType (typedef-11.16)</code>
+        <div class="sect2" id="local-type.typedef-64.16">
+          <h3>9.121. The complex type <code>group[siri:DescriptionGroup]/InfoLinks#complexType (typedef-64.16)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -84038,7 +84038,7 @@
                       <br/>
                       <code>  /InfoLinks #complexType</code>
                       <br/>
-                      <code>  (typedef-11.16)</code>
+                      <code>  (typedef-64.16)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -84080,8 +84080,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-79.16">
-          <h3>9.122. The complex type <code>complexType[siri:DriverMessageStructure]/MessageContents#complexType (typedef-79.16)</code>
+        <div class="sect2" id="local-type.typedef-74.16">
+          <h3>9.122. The complex type <code>complexType[siri:DriverMessageStructure]/MessageContents#complexType (typedef-74.16)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -84101,7 +84101,7 @@
                       <br/>
                       <code>  /MessageContents #complexType</code>
                       <br/>
-                      <code>  (typedef-79.16)</code>
+                      <code>  (typedef-74.16)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -84143,8 +84143,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-79.17">
-          <h3>9.123. The complex type <code>complexType[siri:DriverMessageStructure]/DriverScope#complexType (typedef-79.17)</code>
+        <div class="sect2" id="local-type.typedef-74.17">
+          <h3>9.123. The complex type <code>complexType[siri:DriverMessageStructure]/DriverScope#complexType (typedef-74.17)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -84164,7 +84164,7 @@
                       <br/>
                       <code>  /DriverScope #complexType</code>
                       <br/>
-                      <code>  (typedef-79.17)</code>
+                      <code>  (typedef-74.17)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -86657,7 +86657,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-73.1" title="local-type: typedef-73.1">local-type: typedef-73.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-80.1" title="local-type: typedef-80.1">local-type: typedef-80.1</a>
                       </em>
                     </p>
                   </td>
@@ -86719,7 +86719,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-73.2" title="local-type: typedef-73.2">local-type: typedef-73.2</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-80.2" title="local-type: typedef-80.2">local-type: typedef-80.2</a>
                       </em>
                     </p>
                   </td>
@@ -87487,7 +87487,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-73.1" title="local-type: typedef-73.1">local-type: typedef-73.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-80.1" title="local-type: typedef-80.1">local-type: typedef-80.1</a>
                       </em>
                     </p>
                   </td>
@@ -87549,7 +87549,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-73.2" title="local-type: typedef-73.2">local-type: typedef-73.2</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-80.2" title="local-type: typedef-80.2">local-type: typedef-80.2</a>
                       </em>
                     </p>
                   </td>
@@ -92569,8 +92569,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-73.2">
-          <h3>10.51. The complex type <code>element[siri:ServiceFeaturesRequest]#complexType (typedef-73.2)</code>
+        <div class="sect2" id="local-type.typedef-80.2">
+          <h3>10.51. The complex type <code>element[siri:ServiceFeaturesRequest]#complexType (typedef-80.2)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -92590,7 +92590,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-73.2)</code>
+                      <code>  (typedef-80.2)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -92808,8 +92808,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-73.1">
-          <h3>10.52. The complex type <code>element[siri:StopPointsRequest]#complexType (typedef-73.1)</code>
+        <div class="sect2" id="local-type.typedef-80.1">
+          <h3>10.52. The complex type <code>element[siri:StopPointsRequest]#complexType (typedef-80.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -92829,7 +92829,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-73.1)</code>
+                      <code>  (typedef-80.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -93219,8 +93219,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-73.1">
-          <h3>10.53. The complex type <code>element[siri:StopPointsRequest]#complexType (typedef-73.1)</code>
+        <div class="sect2" id="local-type.typedef-80.1">
+          <h3>10.53. The complex type <code>element[siri:StopPointsRequest]#complexType (typedef-80.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -93240,7 +93240,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-73.1)</code>
+                      <code>  (typedef-80.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -93630,8 +93630,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-73.2">
-          <h3>10.54. The complex type <code>element[siri:ServiceFeaturesRequest]#complexType (typedef-73.2)</code>
+        <div class="sect2" id="local-type.typedef-80.2">
+          <h3>10.54. The complex type <code>element[siri:ServiceFeaturesRequest]#complexType (typedef-80.2)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -93651,7 +93651,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-73.2)</code>
+                      <code>  (typedef-80.2)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -93869,8 +93869,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-73.1">
-          <h3>10.55. The complex type <code>element[siri:StopPointsRequest]#complexType (typedef-73.1)</code>
+        <div class="sect2" id="local-type.typedef-80.1">
+          <h3>10.55. The complex type <code>element[siri:StopPointsRequest]#complexType (typedef-80.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -93890,7 +93890,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-73.1)</code>
+                      <code>  (typedef-80.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -94280,8 +94280,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-73.2">
-          <h3>10.56. The complex type <code>element[siri:ServiceFeaturesRequest]#complexType (typedef-73.2)</code>
+        <div class="sect2" id="local-type.typedef-80.2">
+          <h3>10.56. The complex type <code>element[siri:ServiceFeaturesRequest]#complexType (typedef-80.2)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -94301,7 +94301,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-73.2)</code>
+                      <code>  (typedef-80.2)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -95354,7 +95354,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-76.1" title="local-type: typedef-76.1">local-type: typedef-76.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-73.1" title="local-type: typedef-73.1">local-type: typedef-73.1</a>
                       </em>
                     </p>
                   </td>
@@ -95847,7 +95847,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-76.4" title="local-type: typedef-76.4">local-type: typedef-76.4</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-73.4" title="local-type: typedef-73.4">local-type: typedef-73.4</a>
                       </em>
                     </p>
                   </td>
@@ -96761,7 +96761,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-76.1" title="local-type: typedef-76.1">local-type: typedef-76.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-73.1" title="local-type: typedef-73.1">local-type: typedef-73.1</a>
                       </em>
                     </p>
                   </td>
@@ -97094,7 +97094,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-76.2" title="local-type: typedef-76.2">local-type: typedef-76.2</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-73.2" title="local-type: typedef-73.2">local-type: typedef-73.2</a>
                       </em>
                     </p>
                   </td>
@@ -97118,7 +97118,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-76.3" title="local-type: typedef-76.3">local-type: typedef-76.3</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-73.3" title="local-type: typedef-73.3">local-type: typedef-73.3</a>
                       </em>
                     </p>
                   </td>
@@ -97634,8 +97634,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-76.4">
-          <h3>11.23. The complex type <code>element[siri:EstimatedTimetablePermissions]#complexType (typedef-76.4)</code>
+        <div class="sect2" id="local-type.typedef-73.4">
+          <h3>11.23. The complex type <code>element[siri:EstimatedTimetablePermissions]#complexType (typedef-73.4)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -97655,7 +97655,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-76.4)</code>
+                      <code>  (typedef-73.4)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -97729,8 +97729,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-76.1">
-          <h3>11.24. The complex type <code>group[siri:EstimatedTimetableTopicGroup]/Lines#complexType (typedef-76.1)</code>
+        <div class="sect2" id="local-type.typedef-73.1">
+          <h3>11.24. The complex type <code>group[siri:EstimatedTimetableTopicGroup]/Lines#complexType (typedef-73.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -97750,7 +97750,7 @@
                       <br/>
                       <code>  /Lines #complexType</code>
                       <br/>
-                      <code>  (typedef-76.1)</code>
+                      <code>  (typedef-73.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -97792,8 +97792,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-76.4">
-          <h3>11.25. The complex type <code>element[siri:EstimatedTimetablePermissions]#complexType (typedef-76.4)</code>
+        <div class="sect2" id="local-type.typedef-73.4">
+          <h3>11.25. The complex type <code>element[siri:EstimatedTimetablePermissions]#complexType (typedef-73.4)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -97813,7 +97813,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-76.4)</code>
+                      <code>  (typedef-73.4)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -97887,8 +97887,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-76.1">
-          <h3>11.26. The complex type <code>group[siri:EstimatedTimetableTopicGroup]/Lines#complexType (typedef-76.1)</code>
+        <div class="sect2" id="local-type.typedef-73.1">
+          <h3>11.26. The complex type <code>group[siri:EstimatedTimetableTopicGroup]/Lines#complexType (typedef-73.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -97908,7 +97908,7 @@
                       <br/>
                       <code>  /Lines #complexType</code>
                       <br/>
-                      <code>  (typedef-76.1)</code>
+                      <code>  (typedef-73.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -97950,8 +97950,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-76.2">
-          <h3>11.27. The complex type <code>complexType[siri:EstimatedTimetableServiceCapabilitiesStructure]/TopicFiltering#complexType (typedef-76.2)</code>
+        <div class="sect2" id="local-type.typedef-73.2">
+          <h3>11.27. The complex type <code>complexType[siri:EstimatedTimetableServiceCapabilitiesStructure]/TopicFiltering#complexType (typedef-73.2)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -97971,7 +97971,7 @@
                       <br/>
                       <code>  /TopicFiltering #complexType</code>
                       <br/>
-                      <code>  (typedef-76.2)</code>
+                      <code>  (typedef-73.2)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -98161,8 +98161,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-76.3">
-          <h3>11.28. The complex type <code>complexType[siri:EstimatedTimetableServiceCapabilitiesStructure]/RequestPolicy#complexType (typedef-76.3)</code>
+        <div class="sect2" id="local-type.typedef-73.3">
+          <h3>11.28. The complex type <code>complexType[siri:EstimatedTimetableServiceCapabilitiesStructure]/RequestPolicy#complexType (typedef-73.3)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -98182,7 +98182,7 @@
                       <br/>
                       <code>  /RequestPolicy #complexType</code>
                       <br/>
-                      <code>  (typedef-76.3)</code>
+                      <code>  (typedef-73.3)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -100093,7 +100093,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-86.5" title="local-type: typedef-86.5">local-type: typedef-86.5</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-78.5" title="local-type: typedef-78.5">local-type: typedef-78.5</a>
                       </em>
                     </p>
                   </td>
@@ -101290,7 +101290,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-86.1" title="local-type: typedef-86.1">local-type: typedef-86.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-78.1" title="local-type: typedef-78.1">local-type: typedef-78.1</a>
                       </em>
                     </p>
                   </td>
@@ -101314,7 +101314,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-86.2" title="local-type: typedef-86.2">local-type: typedef-86.2</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-78.2" title="local-type: typedef-78.2">local-type: typedef-78.2</a>
                       </em>
                     </p>
                   </td>
@@ -101362,7 +101362,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-86.3" title="local-type: typedef-86.3">local-type: typedef-86.3</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-78.3" title="local-type: typedef-78.3">local-type: typedef-78.3</a>
                       </em>
                     </p>
                   </td>
@@ -101386,7 +101386,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-86.4" title="local-type: typedef-86.4">local-type: typedef-86.4</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-78.4" title="local-type: typedef-78.4">local-type: typedef-78.4</a>
                       </em>
                     </p>
                   </td>
@@ -101545,7 +101545,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-61.1" title="local-type: typedef-61.1">local-type: typedef-61.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-44.1" title="local-type: typedef-44.1">local-type: typedef-44.1</a>
                       </em>
                     </p>
                   </td>
@@ -101579,7 +101579,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-2.2" title="local-type: typedef-2.2">local-type: typedef-2.2</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-65.2" title="local-type: typedef-65.2">local-type: typedef-65.2</a>
                       </em>
                     </p>
                   </td>
@@ -101608,7 +101608,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-2.1" title="local-type: typedef-2.1">local-type: typedef-2.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-65.1" title="local-type: typedef-65.1">local-type: typedef-65.1</a>
                       </em>
                     </p>
                   </td>
@@ -101864,8 +101864,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-86.5">
-          <h3>12.24. The complex type <code>element[siri:FacilityMonitoringPermissions]#complexType (typedef-86.5)</code>
+        <div class="sect2" id="local-type.typedef-78.5">
+          <h3>12.24. The complex type <code>element[siri:FacilityMonitoringPermissions]#complexType (typedef-78.5)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -101885,7 +101885,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-86.5)</code>
+                      <code>  (typedef-78.5)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -101959,8 +101959,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-86.5">
-          <h3>12.25. The complex type <code>element[siri:FacilityMonitoringPermissions]#complexType (typedef-86.5)</code>
+        <div class="sect2" id="local-type.typedef-78.5">
+          <h3>12.25. The complex type <code>element[siri:FacilityMonitoringPermissions]#complexType (typedef-78.5)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -101980,7 +101980,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-86.5)</code>
+                      <code>  (typedef-78.5)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -102054,8 +102054,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-86.1">
-          <h3>12.26. The complex type <code>complexType[siri:FacilityMonitoringServiceCapabilitiesStructure]/TopicFiltering#complexType (typedef-86.1)</code>
+        <div class="sect2" id="local-type.typedef-78.1">
+          <h3>12.26. The complex type <code>complexType[siri:FacilityMonitoringServiceCapabilitiesStructure]/TopicFiltering#complexType (typedef-78.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -102075,7 +102075,7 @@
                       <br/>
                       <code>  /TopicFiltering #complexType</code>
                       <br/>
-                      <code>  (typedef-86.1)</code>
+                      <code>  (typedef-78.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -102340,8 +102340,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-86.2">
-          <h3>12.27. The complex type <code>complexType[siri:FacilityMonitoringServiceCapabilitiesStructure]/RequestPolicy#complexType (typedef-86.2)</code>
+        <div class="sect2" id="local-type.typedef-78.2">
+          <h3>12.27. The complex type <code>complexType[siri:FacilityMonitoringServiceCapabilitiesStructure]/RequestPolicy#complexType (typedef-78.2)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -102361,7 +102361,7 @@
                       <br/>
                       <code>  /RequestPolicy #complexType</code>
                       <br/>
-                      <code>  (typedef-86.2)</code>
+                      <code>  (typedef-78.2)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -102533,8 +102533,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-86.3">
-          <h3>12.28. The complex type <code>complexType[siri:FacilityMonitoringServiceCapabilitiesStructure]/AccessControl#complexType (typedef-86.3)</code>
+        <div class="sect2" id="local-type.typedef-78.3">
+          <h3>12.28. The complex type <code>complexType[siri:FacilityMonitoringServiceCapabilitiesStructure]/AccessControl#complexType (typedef-78.3)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -102554,7 +102554,7 @@
                       <br/>
                       <code>  /AccessControl #complexType</code>
                       <br/>
-                      <code>  (typedef-86.3)</code>
+                      <code>  (typedef-78.3)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -102655,8 +102655,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-86.4">
-          <h3>12.29. The complex type <code>complexType[siri:FacilityMonitoringServiceCapabilitiesStructure]/ResponseFeatures#complexType (typedef-86.4)</code>
+        <div class="sect2" id="local-type.typedef-78.4">
+          <h3>12.29. The complex type <code>complexType[siri:FacilityMonitoringServiceCapabilitiesStructure]/ResponseFeatures#complexType (typedef-78.4)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -102676,7 +102676,7 @@
                       <br/>
                       <code>  /ResponseFeatures #complexType</code>
                       <br/>
-                      <code>  (typedef-86.4)</code>
+                      <code>  (typedef-78.4)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -102736,8 +102736,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-61.1">
-          <h3>12.30. The complex type <code>complexType[siri:AbstractPermissionStructure]/GeneralCapabilities#complexType (typedef-61.1)</code>
+        <div class="sect2" id="local-type.typedef-44.1">
+          <h3>12.30. The complex type <code>complexType[siri:AbstractPermissionStructure]/GeneralCapabilities#complexType (typedef-44.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -102757,7 +102757,7 @@
                       <br/>
                       <code>  /GeneralCapabilities #complexType</code>
                       <br/>
-                      <code>  (typedef-61.1)</code>
+                      <code>  (typedef-44.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -102825,8 +102825,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-2.2">
-          <h3>12.31. The complex type <code>element[siri:OperatorPermissions]#complexType (typedef-2.2)</code>
+        <div class="sect2" id="local-type.typedef-65.2">
+          <h3>12.31. The complex type <code>element[siri:OperatorPermissions]#complexType (typedef-65.2)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -102846,7 +102846,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-2.2)</code>
+                      <code>  (typedef-65.2)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -102931,8 +102931,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-2.1">
-          <h3>12.32. The complex type <code>element[siri:LinePermissions]#complexType (typedef-2.1)</code>
+        <div class="sect2" id="local-type.typedef-65.1">
+          <h3>12.32. The complex type <code>element[siri:LinePermissions]#complexType (typedef-65.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -102952,7 +102952,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-2.1)</code>
+                      <code>  (typedef-65.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -104131,7 +104131,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-81.2" title="local-type: typedef-81.2">local-type: typedef-81.2</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-75.2" title="local-type: typedef-75.2">local-type: typedef-75.2</a>
                       </em>
                     </p>
                   </td>
@@ -105074,7 +105074,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-81.1" title="local-type: typedef-81.1">local-type: typedef-81.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-75.1" title="local-type: typedef-75.1">local-type: typedef-75.1</a>
                       </em>
                     </p>
                   </td>
@@ -105256,7 +105256,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-61.1" title="local-type: typedef-61.1">local-type: typedef-61.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-44.1" title="local-type: typedef-44.1">local-type: typedef-44.1</a>
                       </em>
                     </p>
                   </td>
@@ -105289,7 +105289,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-81.3" title="local-type: typedef-81.3">local-type: typedef-81.3</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-75.3" title="local-type: typedef-75.3">local-type: typedef-75.3</a>
                       </em>
                     </p>
                   </td>
@@ -106115,8 +106115,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-81.2">
-          <h3>13.29. The complex type <code>element[siri:GeneralMessagePermissions]#complexType (typedef-81.2)</code>
+        <div class="sect2" id="local-type.typedef-75.2">
+          <h3>13.29. The complex type <code>element[siri:GeneralMessagePermissions]#complexType (typedef-75.2)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -106136,7 +106136,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-81.2)</code>
+                      <code>  (typedef-75.2)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -106210,8 +106210,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-81.2">
-          <h3>13.30. The complex type <code>element[siri:GeneralMessagePermissions]#complexType (typedef-81.2)</code>
+        <div class="sect2" id="local-type.typedef-75.2">
+          <h3>13.30. The complex type <code>element[siri:GeneralMessagePermissions]#complexType (typedef-75.2)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -106231,7 +106231,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-81.2)</code>
+                      <code>  (typedef-75.2)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -106305,8 +106305,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-81.1">
-          <h3>13.31. The complex type <code>complexType[siri:GeneralMessageServiceCapabilitiesStructure]/TopicFiltering#complexType (typedef-81.1)</code>
+        <div class="sect2" id="local-type.typedef-75.1">
+          <h3>13.31. The complex type <code>complexType[siri:GeneralMessageServiceCapabilitiesStructure]/TopicFiltering#complexType (typedef-75.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -106326,7 +106326,7 @@
                       <br/>
                       <code>  /TopicFiltering #complexType</code>
                       <br/>
-                      <code>  (typedef-81.1)</code>
+                      <code>  (typedef-75.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -106392,8 +106392,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-61.1">
-          <h3>13.32. The complex type <code>complexType[siri:AbstractPermissionStructure]/GeneralCapabilities#complexType (typedef-61.1)</code>
+        <div class="sect2" id="local-type.typedef-44.1">
+          <h3>13.32. The complex type <code>complexType[siri:AbstractPermissionStructure]/GeneralCapabilities#complexType (typedef-44.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -106413,7 +106413,7 @@
                       <br/>
                       <code>  /GeneralCapabilities #complexType</code>
                       <br/>
-                      <code>  (typedef-61.1)</code>
+                      <code>  (typedef-44.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -106481,8 +106481,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-81.3">
-          <h3>13.33. The complex type <code>complexType[siri:GeneralMessageServicePermissionStructure]/InfoChannelPermissions#complexType (typedef-81.3)</code>
+        <div class="sect2" id="local-type.typedef-75.3">
+          <h3>13.33. The complex type <code>complexType[siri:GeneralMessageServicePermissionStructure]/InfoChannelPermissions#complexType (typedef-75.3)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -106502,7 +106502,7 @@
                       <br/>
                       <code>  /InfoChannelPermissions #complexType</code>
                       <br/>
-                      <code>  (typedef-81.3)</code>
+                      <code>  (typedef-75.3)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -110380,7 +110380,7 @@
                   </td>
                 </tr>
                 <tr>
-                  <td colspan="1" rowspan="4" class="tableblock halign-left valign-top">
+                  <td colspan="1" rowspan="5" class="tableblock halign-left valign-top">
                     <a shape="rect" href="#group.siri:JourneyInfoGroup" title="siri:JourneyInfoGroup">siri:JourneyInfoGroup</a>
                   </td>
                   <td colspan="2" rowspan="1" class="tableblock halign-left valign-top">
@@ -110401,6 +110401,26 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock darkbrown">For train services with named journeys. Train name, e.g. “West Coast Express”. If omitted: No train name. Inherited property. (Unbounded since SIRI 2.0)</p>
+                  </td>
+                </tr>
+                <tr>
+                  <td colspan="2" rowspan="1" class="tableblock halign-left valign-top">
+                    <p class="tableblock">
+                      <code>siri:DeadRun</code>
+                    </p>
+                  </td>
+                  <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
+                    <p class="tableblock">
+                      <span title="optional, single">0:1</span>
+                    </p>
+                  </td>
+                  <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
+                    <p class="tableblock">
+                      <em>xs:boolean</em>
+                    </p>
+                  </td>
+                  <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
+                    <p class="tableblock darkbrown">Allows to flag if the VehicleJourney is a dead run, so it is clear that only there is no expectation of an associated service to it. +v2.3</p>
                   </td>
                 </tr>
                 <tr>
@@ -110708,7 +110728,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-8.6" title="local-type: typedef-8.6">local-type: typedef-8.6</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-60.6" title="local-type: typedef-60.6">local-type: typedef-60.6</a>
                       </em>
                     </p>
                   </td>
@@ -110729,7 +110749,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-8.7" title="local-type: typedef-8.7">local-type: typedef-8.7</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-60.7" title="local-type: typedef-60.7">local-type: typedef-60.7</a>
                       </em>
                     </p>
                   </td>
@@ -110753,7 +110773,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-24.2" title="local-type: typedef-24.2">local-type: typedef-24.2</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-62.2" title="local-type: typedef-62.2">local-type: typedef-62.2</a>
                       </em>
                     </p>
                   </td>
@@ -110774,7 +110794,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-24.3" title="local-type: typedef-24.3">local-type: typedef-24.3</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-62.3" title="local-type: typedef-62.3">local-type: typedef-62.3</a>
                       </em>
                     </p>
                   </td>
@@ -110795,7 +110815,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-24.4" title="local-type: typedef-24.4">local-type: typedef-24.4</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-62.4" title="local-type: typedef-62.4">local-type: typedef-62.4</a>
                       </em>
                     </p>
                   </td>
@@ -110823,7 +110843,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-3.1" title="local-type: typedef-3.1">local-type: typedef-3.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-63.1" title="local-type: typedef-63.1">local-type: typedef-63.1</a>
                       </em>
                     </p>
                   </td>
@@ -111538,7 +111558,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-3.2" title="local-type: typedef-3.2">local-type: typedef-3.2</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-63.2" title="local-type: typedef-63.2">local-type: typedef-63.2</a>
                       </em>
                     </p>
                   </td>
@@ -113573,8 +113593,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-8.6">
-          <h3>14.37. The complex type <code>group[siri:DatedTrainOperationalInfoGroup]/TrainNumbers#complexType (typedef-8.6)</code>
+        <div class="sect2" id="local-type.typedef-60.6">
+          <h3>14.37. The complex type <code>group[siri:DatedTrainOperationalInfoGroup]/TrainNumbers#complexType (typedef-60.6)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -113594,7 +113614,7 @@
                       <br/>
                       <code>  /TrainNumbers #complexType</code>
                       <br/>
-                      <code>  (typedef-8.6)</code>
+                      <code>  (typedef-60.6)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -113636,8 +113656,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-8.7">
-          <h3>14.38. The complex type <code>group[siri:DatedTrainOperationalInfoGroup]/JourneyParts#complexType (typedef-8.7)</code>
+        <div class="sect2" id="local-type.typedef-60.7">
+          <h3>14.38. The complex type <code>group[siri:DatedTrainOperationalInfoGroup]/JourneyParts#complexType (typedef-60.7)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -113657,7 +113677,7 @@
                       <br/>
                       <code>  /JourneyParts #complexType</code>
                       <br/>
-                      <code>  (typedef-8.7)</code>
+                      <code>  (typedef-60.7)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -113699,8 +113719,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-24.2">
-          <h3>14.39. The complex type <code>group[siri:JourneyFormationGroup]/TrainElements#complexType (typedef-24.2)</code>
+        <div class="sect2" id="local-type.typedef-62.2">
+          <h3>14.39. The complex type <code>group[siri:JourneyFormationGroup]/TrainElements#complexType (typedef-62.2)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -113720,7 +113740,7 @@
                       <br/>
                       <code>  /TrainElements #complexType</code>
                       <br/>
-                      <code>  (typedef-24.2)</code>
+                      <code>  (typedef-62.2)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -113807,8 +113827,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-24.3">
-          <h3>14.40. The complex type <code>group[siri:JourneyFormationGroup]/Trains#complexType (typedef-24.3)</code>
+        <div class="sect2" id="local-type.typedef-62.3">
+          <h3>14.40. The complex type <code>group[siri:JourneyFormationGroup]/Trains#complexType (typedef-62.3)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -113828,7 +113848,7 @@
                       <br/>
                       <code>  /Trains #complexType</code>
                       <br/>
-                      <code>  (typedef-24.3)</code>
+                      <code>  (typedef-62.3)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -113915,8 +113935,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-24.4">
-          <h3>14.41. The complex type <code>group[siri:JourneyFormationGroup]/CompoundTrains#complexType (typedef-24.4)</code>
+        <div class="sect2" id="local-type.typedef-62.4">
+          <h3>14.41. The complex type <code>group[siri:JourneyFormationGroup]/CompoundTrains#complexType (typedef-62.4)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -113936,7 +113956,7 @@
                       <br/>
                       <code>  /CompoundTrains #complexType</code>
                       <br/>
-                      <code>  (typedef-24.4)</code>
+                      <code>  (typedef-62.4)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -114023,8 +114043,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-3.1">
-          <h3>14.42. The complex type <code>complexType[siri:DatedVehicleJourneyStructure]/DatedCalls#complexType (typedef-3.1)</code>
+        <div class="sect2" id="local-type.typedef-63.1">
+          <h3>14.42. The complex type <code>complexType[siri:DatedVehicleJourneyStructure]/DatedCalls#complexType (typedef-63.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -114044,7 +114064,7 @@
                       <br/>
                       <code>  /DatedCalls #complexType</code>
                       <br/>
-                      <code>  (typedef-3.1)</code>
+                      <code>  (typedef-63.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -114087,8 +114107,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-3.2">
-          <h3>14.43. The complex type <code>complexType[siri:RemovedDatedVehicleJourneyStructure]/TrainNumbers#complexType (typedef-3.2)</code>
+        <div class="sect2" id="local-type.typedef-63.2">
+          <h3>14.43. The complex type <code>complexType[siri:RemovedDatedVehicleJourneyStructure]/TrainNumbers#complexType (typedef-63.2)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -114108,7 +114128,7 @@
                       <br/>
                       <code>  /TrainNumbers #complexType</code>
                       <br/>
-                      <code>  (typedef-3.2)</code>
+                      <code>  (typedef-63.2)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -118699,7 +118719,7 @@
                   </td>
                 </tr>
                 <tr>
-                  <td colspan="1" rowspan="4" class="tableblock halign-left valign-top">
+                  <td colspan="1" rowspan="5" class="tableblock halign-left valign-top">
                     <a shape="rect" href="#group.siri:JourneyInfoGroup" title="siri:JourneyInfoGroup">siri:JourneyInfoGroup</a>
                   </td>
                   <td colspan="2" rowspan="1" class="tableblock halign-left valign-top">
@@ -118720,6 +118740,26 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock darkbrown">For train services with named journeys. Train name, e.g. “West Coast Express”. If omitted: No train name. Inherited property. (Unbounded since SIRI 2.0)</p>
+                  </td>
+                </tr>
+                <tr>
+                  <td colspan="2" rowspan="1" class="tableblock halign-left valign-top">
+                    <p class="tableblock">
+                      <code>siri:DeadRun</code>
+                    </p>
+                  </td>
+                  <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
+                    <p class="tableblock">
+                      <span title="optional, single">0:1</span>
+                    </p>
+                  </td>
+                  <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
+                    <p class="tableblock">
+                      <em>xs:boolean</em>
+                    </p>
+                  </td>
+                  <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
+                    <p class="tableblock darkbrown">Allows to flag if the VehicleJourney is a dead run, so it is clear that only there is no expectation of an associated service to it. +v2.3</p>
                   </td>
                 </tr>
                 <tr>
@@ -119567,7 +119607,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-8.4" title="local-type: typedef-8.4">local-type: typedef-8.4</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-60.4" title="local-type: typedef-60.4">local-type: typedef-60.4</a>
                       </em>
                     </p>
                   </td>
@@ -119588,7 +119628,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-8.5" title="local-type: typedef-8.5">local-type: typedef-8.5</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-60.5" title="local-type: typedef-60.5">local-type: typedef-60.5</a>
                       </em>
                     </p>
                   </td>
@@ -119612,7 +119652,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-24.2" title="local-type: typedef-24.2">local-type: typedef-24.2</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-62.2" title="local-type: typedef-62.2">local-type: typedef-62.2</a>
                       </em>
                     </p>
                   </td>
@@ -119633,7 +119673,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-24.3" title="local-type: typedef-24.3">local-type: typedef-24.3</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-62.3" title="local-type: typedef-62.3">local-type: typedef-62.3</a>
                       </em>
                     </p>
                   </td>
@@ -119654,7 +119694,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-24.4" title="local-type: typedef-24.4">local-type: typedef-24.4</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-62.4" title="local-type: typedef-62.4">local-type: typedef-62.4</a>
                       </em>
                     </p>
                   </td>
@@ -119678,7 +119718,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-16.1" title="local-type: typedef-16.1">local-type: typedef-16.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-67.1" title="local-type: typedef-67.1">local-type: typedef-67.1</a>
                       </em>
                     </p>
                   </td>
@@ -119702,7 +119742,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-16.2" title="local-type: typedef-16.2">local-type: typedef-16.2</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-67.2" title="local-type: typedef-67.2">local-type: typedef-67.2</a>
                       </em>
                     </p>
                   </td>
@@ -121084,8 +121124,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-8.4">
-          <h3>15.16. The complex type <code>group[siri:TrainOperationalInfoGroup]/TrainNumbers#complexType (typedef-8.4)</code>
+        <div class="sect2" id="local-type.typedef-60.4">
+          <h3>15.16. The complex type <code>group[siri:TrainOperationalInfoGroup]/TrainNumbers#complexType (typedef-60.4)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -121105,7 +121145,7 @@
                       <br/>
                       <code>  /TrainNumbers #complexType</code>
                       <br/>
-                      <code>  (typedef-8.4)</code>
+                      <code>  (typedef-60.4)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -121147,8 +121187,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-8.5">
-          <h3>15.17. The complex type <code>group[siri:TrainOperationalInfoGroup]/JourneyParts#complexType (typedef-8.5)</code>
+        <div class="sect2" id="local-type.typedef-60.5">
+          <h3>15.17. The complex type <code>group[siri:TrainOperationalInfoGroup]/JourneyParts#complexType (typedef-60.5)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -121168,7 +121208,7 @@
                       <br/>
                       <code>  /JourneyParts #complexType</code>
                       <br/>
-                      <code>  (typedef-8.5)</code>
+                      <code>  (typedef-60.5)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -121210,8 +121250,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-24.2">
-          <h3>15.18. The complex type <code>group[siri:JourneyFormationGroup]/TrainElements#complexType (typedef-24.2)</code>
+        <div class="sect2" id="local-type.typedef-62.2">
+          <h3>15.18. The complex type <code>group[siri:JourneyFormationGroup]/TrainElements#complexType (typedef-62.2)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -121231,7 +121271,7 @@
                       <br/>
                       <code>  /TrainElements #complexType</code>
                       <br/>
-                      <code>  (typedef-24.2)</code>
+                      <code>  (typedef-62.2)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -121318,8 +121358,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-24.3">
-          <h3>15.19. The complex type <code>group[siri:JourneyFormationGroup]/Trains#complexType (typedef-24.3)</code>
+        <div class="sect2" id="local-type.typedef-62.3">
+          <h3>15.19. The complex type <code>group[siri:JourneyFormationGroup]/Trains#complexType (typedef-62.3)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -121339,7 +121379,7 @@
                       <br/>
                       <code>  /Trains #complexType</code>
                       <br/>
-                      <code>  (typedef-24.3)</code>
+                      <code>  (typedef-62.3)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -121426,8 +121466,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-24.4">
-          <h3>15.20. The complex type <code>group[siri:JourneyFormationGroup]/CompoundTrains#complexType (typedef-24.4)</code>
+        <div class="sect2" id="local-type.typedef-62.4">
+          <h3>15.20. The complex type <code>group[siri:JourneyFormationGroup]/CompoundTrains#complexType (typedef-62.4)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -121447,7 +121487,7 @@
                       <br/>
                       <code>  /CompoundTrains #complexType</code>
                       <br/>
-                      <code>  (typedef-24.4)</code>
+                      <code>  (typedef-62.4)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -121534,8 +121574,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-16.1">
-          <h3>15.21. The complex type <code>complexType[siri:EstimatedVehicleJourneyStructure]/RecordedCalls#complexType (typedef-16.1)</code>
+        <div class="sect2" id="local-type.typedef-67.1">
+          <h3>15.21. The complex type <code>complexType[siri:EstimatedVehicleJourneyStructure]/RecordedCalls#complexType (typedef-67.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -121555,7 +121595,7 @@
                       <br/>
                       <code>  /RecordedCalls #complexType</code>
                       <br/>
-                      <code>  (typedef-16.1)</code>
+                      <code>  (typedef-67.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -121598,8 +121638,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-16.2">
-          <h3>15.22. The complex type <code>complexType[siri:EstimatedVehicleJourneyStructure]/EstimatedCalls#complexType (typedef-16.2)</code>
+        <div class="sect2" id="local-type.typedef-67.2">
+          <h3>15.22. The complex type <code>complexType[siri:EstimatedVehicleJourneyStructure]/EstimatedCalls#complexType (typedef-67.2)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -121619,7 +121659,7 @@
                       <br/>
                       <code>  /EstimatedCalls #complexType</code>
                       <br/>
-                      <code>  (typedef-16.2)</code>
+                      <code>  (typedef-67.2)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -126781,7 +126821,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-26.2" title="local-type: typedef-26.2">local-type: typedef-26.2</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-57.2" title="local-type: typedef-57.2">local-type: typedef-57.2</a>
                       </em>
                     </p>
                   </td>
@@ -126802,7 +126842,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-26.3" title="local-type: typedef-26.3">local-type: typedef-26.3</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-57.3" title="local-type: typedef-57.3">local-type: typedef-57.3</a>
                       </em>
                     </p>
                   </td>
@@ -127499,7 +127539,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-26.6" title="local-type: typedef-26.6">local-type: typedef-26.6</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-57.6" title="local-type: typedef-57.6">local-type: typedef-57.6</a>
                       </em>
                     </p>
                   </td>
@@ -127783,7 +127823,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-26.5" title="local-type: typedef-26.5">local-type: typedef-26.5</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-57.5" title="local-type: typedef-57.5">local-type: typedef-57.5</a>
                       </em>
                     </p>
                   </td>
@@ -128718,7 +128758,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-26.1" title="local-type: typedef-26.1">local-type: typedef-26.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-57.1" title="local-type: typedef-57.1">local-type: typedef-57.1</a>
                       </em>
                     </p>
                   </td>
@@ -128838,7 +128878,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-26.2" title="local-type: typedef-26.2">local-type: typedef-26.2</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-57.2" title="local-type: typedef-57.2">local-type: typedef-57.2</a>
                       </em>
                     </p>
                   </td>
@@ -128859,7 +128899,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-26.3" title="local-type: typedef-26.3">local-type: typedef-26.3</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-57.3" title="local-type: typedef-57.3">local-type: typedef-57.3</a>
                       </em>
                     </p>
                   </td>
@@ -129270,7 +129310,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-26.4" title="local-type: typedef-26.4">local-type: typedef-26.4</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-57.4" title="local-type: typedef-57.4">local-type: typedef-57.4</a>
                       </em>
                     </p>
                   </td>
@@ -129777,8 +129817,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-26.2">
-          <h3>17.32. The complex type <code>group[siri:FacilityAccessibilityGroup]/Limitations#complexType (typedef-26.2)</code>
+        <div class="sect2" id="local-type.typedef-57.2">
+          <h3>17.32. The complex type <code>group[siri:FacilityAccessibilityGroup]/Limitations#complexType (typedef-57.2)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -129798,7 +129838,7 @@
                       <br/>
                       <code>  /Limitations #complexType</code>
                       <br/>
-                      <code>  (typedef-26.2)</code>
+                      <code>  (typedef-57.2)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -129954,8 +129994,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-26.3">
-          <h3>17.33. The complex type <code>group[siri:FacilityAccessibilityGroup]/Suitabilities#complexType (typedef-26.3)</code>
+        <div class="sect2" id="local-type.typedef-57.3">
+          <h3>17.33. The complex type <code>group[siri:FacilityAccessibilityGroup]/Suitabilities#complexType (typedef-57.3)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -129975,7 +130015,7 @@
                       <br/>
                       <code>  /Suitabilities #complexType</code>
                       <br/>
-                      <code>  (typedef-26.3)</code>
+                      <code>  (typedef-57.3)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -130017,8 +130057,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-26.6">
-          <h3>17.34. The complex type <code>complexType[siri:EquipmentAvailabilityStructure]/EquipmentFeatures#complexType (typedef-26.6)</code>
+        <div class="sect2" id="local-type.typedef-57.6">
+          <h3>17.34. The complex type <code>complexType[siri:EquipmentAvailabilityStructure]/EquipmentFeatures#complexType (typedef-57.6)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -130038,7 +130078,7 @@
                       <br/>
                       <code>  /EquipmentFeatures #complexType</code>
                       <br/>
-                      <code>  (typedef-26.6)</code>
+                      <code>  (typedef-57.6)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -130080,8 +130120,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-26.5">
-          <h3>17.35. The complex type <code>complexType[siri:FacilityConditionStructure]/MonitoredCounting#complexType (typedef-26.5)</code>
+        <div class="sect2" id="local-type.typedef-57.5">
+          <h3>17.35. The complex type <code>complexType[siri:FacilityConditionStructure]/MonitoredCounting#complexType (typedef-57.5)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -130101,7 +130141,7 @@
                       <br/>
                       <code>  /MonitoredCounting #complexType</code>
                       <br/>
-                      <code>  (typedef-26.5)</code>
+                      <code>  (typedef-57.5)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -130357,7 +130397,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-26.4" title="local-type: typedef-26.4">local-type: typedef-26.4</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-57.4" title="local-type: typedef-57.4">local-type: typedef-57.4</a>
                       </em>
                     </p>
                   </td>
@@ -130394,8 +130434,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-26.4">
-          <h3>17.36. The complex type <code>complexType[siri:MonitoredCountingStructure]/CountedItemsIdList#complexType (typedef-26.4)</code>
+        <div class="sect2" id="local-type.typedef-57.4">
+          <h3>17.36. The complex type <code>complexType[siri:MonitoredCountingStructure]/CountedItemsIdList#complexType (typedef-57.4)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -130415,7 +130455,7 @@
                       <br/>
                       <code>  /CountedItemsIdList #complexType</code>
                       <br/>
-                      <code>  (typedef-26.4)</code>
+                      <code>  (typedef-57.4)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -130458,8 +130498,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-26.1">
-          <h3>17.37. The complex type <code>complexType[siri:FacilityStructure]/Features#complexType (typedef-26.1)</code>
+        <div class="sect2" id="local-type.typedef-57.1">
+          <h3>17.37. The complex type <code>complexType[siri:FacilityStructure]/Features#complexType (typedef-57.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -130479,7 +130519,7 @@
                       <br/>
                       <code>  /Features #complexType</code>
                       <br/>
-                      <code>  (typedef-26.1)</code>
+                      <code>  (typedef-57.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -130521,8 +130561,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-26.2">
-          <h3>17.38. The complex type <code>group[siri:FacilityAccessibilityGroup]/Limitations#complexType (typedef-26.2)</code>
+        <div class="sect2" id="local-type.typedef-57.2">
+          <h3>17.38. The complex type <code>group[siri:FacilityAccessibilityGroup]/Limitations#complexType (typedef-57.2)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -130542,7 +130582,7 @@
                       <br/>
                       <code>  /Limitations #complexType</code>
                       <br/>
-                      <code>  (typedef-26.2)</code>
+                      <code>  (typedef-57.2)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -130698,8 +130738,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-26.3">
-          <h3>17.39. The complex type <code>group[siri:FacilityAccessibilityGroup]/Suitabilities#complexType (typedef-26.3)</code>
+        <div class="sect2" id="local-type.typedef-57.3">
+          <h3>17.39. The complex type <code>group[siri:FacilityAccessibilityGroup]/Suitabilities#complexType (typedef-57.3)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -130719,7 +130759,7 @@
                       <br/>
                       <code>  /Suitabilities #complexType</code>
                       <br/>
-                      <code>  (typedef-26.3)</code>
+                      <code>  (typedef-57.3)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -130761,8 +130801,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-26.4">
-          <h3>17.40. The complex type <code>complexType[siri:MonitoredCountingStructure]/CountedItemsIdList#complexType (typedef-26.4)</code>
+        <div class="sect2" id="local-type.typedef-57.4">
+          <h3>17.40. The complex type <code>complexType[siri:MonitoredCountingStructure]/CountedItemsIdList#complexType (typedef-57.4)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -130782,7 +130822,7 @@
                       <br/>
                       <code>  /CountedItemsIdList #complexType</code>
                       <br/>
-                      <code>  (typedef-26.4)</code>
+                      <code>  (typedef-57.4)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -131722,7 +131762,7 @@
                   </td>
                 </tr>
                 <tr>
-                  <td colspan="1" rowspan="4" class="tableblock halign-left valign-top">
+                  <td colspan="1" rowspan="5" class="tableblock halign-left valign-top">
                     <a shape="rect" href="#group.siri:JourneyInfoGroup" title="siri:JourneyInfoGroup">siri:JourneyInfoGroup</a>
                   </td>
                   <td colspan="2" rowspan="1" class="tableblock halign-left valign-top">
@@ -131743,6 +131783,26 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock darkbrown">For train services with named journeys. Train name, e.g. “West Coast Express”. If omitted: No train name. Inherited property. (Unbounded since SIRI 2.0)</p>
+                  </td>
+                </tr>
+                <tr>
+                  <td colspan="2" rowspan="1" class="tableblock halign-left valign-top">
+                    <p class="tableblock">
+                      <code>siri:DeadRun</code>
+                    </p>
+                  </td>
+                  <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
+                    <p class="tableblock">
+                      <span title="optional, single">0:1</span>
+                    </p>
+                  </td>
+                  <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
+                    <p class="tableblock">
+                      <em>xs:boolean</em>
+                    </p>
+                  </td>
+                  <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
+                    <p class="tableblock darkbrown">Allows to flag if the VehicleJourney is a dead run, so it is clear that only there is no expectation of an associated service to it. +v2.3</p>
                   </td>
                 </tr>
                 <tr>
@@ -132250,12 +132310,12 @@
               <tbody>
                 <tr>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
-                    <p id="local-type.typedef-36.1" class="tableblock">
+                    <p id="local-type.typedef-39.1" class="tableblock">
                       <code>attribute[lang]</code>
                       <br/>
                       <code>  #simpleType</code>
                       <br/>
-                      <code>  (typedef-36.1)</code>
+                      <code>  (typedef-39.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -135912,7 +135972,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-24.2" title="local-type: typedef-24.2">local-type: typedef-24.2</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-62.2" title="local-type: typedef-62.2">local-type: typedef-62.2</a>
                       </em>
                     </p>
                   </td>
@@ -135933,7 +135993,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-24.3" title="local-type: typedef-24.3">local-type: typedef-24.3</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-62.3" title="local-type: typedef-62.3">local-type: typedef-62.3</a>
                       </em>
                     </p>
                   </td>
@@ -135954,7 +136014,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-24.4" title="local-type: typedef-24.4">local-type: typedef-24.4</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-62.4" title="local-type: typedef-62.4">local-type: typedef-62.4</a>
                       </em>
                     </p>
                   </td>
@@ -135994,7 +136054,7 @@
                   </td>
                 </tr>
                 <tr>
-                  <td colspan="1" rowspan="4" class="tableblock halign-left valign-top">
+                  <td colspan="1" rowspan="5" class="tableblock halign-left valign-top">
                     <a shape="rect" href="#group.siri:JourneyInfoGroup" title="siri:JourneyInfoGroup">siri:JourneyInfoGroup</a>
                   </td>
                   <td colspan="2" rowspan="1" class="tableblock halign-left valign-top">
@@ -136015,6 +136075,26 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock darkbrown">For train services with named journeys. Train name, e.g. “West Coast Express”. If omitted: No train name. Inherited property. (Unbounded since SIRI 2.0)</p>
+                  </td>
+                </tr>
+                <tr>
+                  <td colspan="2" rowspan="1" class="tableblock halign-left valign-top">
+                    <p class="tableblock">
+                      <code>siri:DeadRun</code>
+                    </p>
+                  </td>
+                  <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
+                    <p class="tableblock">
+                      <span title="optional, single">0:1</span>
+                    </p>
+                  </td>
+                  <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
+                    <p class="tableblock">
+                      <em>xs:boolean</em>
+                    </p>
+                  </td>
+                  <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
+                    <p class="tableblock darkbrown">Allows to flag if the VehicleJourney is a dead run, so it is clear that only there is no expectation of an associated service to it. +v2.3</p>
                   </td>
                 </tr>
                 <tr>
@@ -136172,7 +136252,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-24.1" title="local-type: typedef-24.1">local-type: typedef-24.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-62.1" title="local-type: typedef-62.1">local-type: typedef-62.1</a>
                       </em>
                     </p>
                   </td>
@@ -139750,7 +139830,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-24.5" title="local-type: typedef-24.5">local-type: typedef-24.5</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-62.5" title="local-type: typedef-62.5">local-type: typedef-62.5</a>
                       </em>
                     </p>
                   </td>
@@ -140131,7 +140211,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-24.7" title="local-type: typedef-24.7">local-type: typedef-24.7</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-62.7" title="local-type: typedef-62.7">local-type: typedef-62.7</a>
                       </em>
                     </p>
                   </td>
@@ -140896,7 +140976,7 @@
                   </td>
                 </tr>
                 <tr>
-                  <td colspan="1" rowspan="4" class="tableblock halign-left valign-top">
+                  <td colspan="1" rowspan="5" class="tableblock halign-left valign-top">
                     <a shape="rect" href="#group.siri:JourneyInfoGroup" title="siri:JourneyInfoGroup">siri:JourneyInfoGroup</a>
                   </td>
                   <td colspan="2" rowspan="1" class="tableblock halign-left valign-top">
@@ -140917,6 +140997,26 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock darkbrown">For train services with named journeys. Train name, e.g. “West Coast Express”. If omitted: No train name. Inherited property. (Unbounded since SIRI 2.0)</p>
+                  </td>
+                </tr>
+                <tr>
+                  <td colspan="2" rowspan="1" class="tableblock halign-left valign-top">
+                    <p class="tableblock">
+                      <code>siri:DeadRun</code>
+                    </p>
+                  </td>
+                  <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
+                    <p class="tableblock">
+                      <span title="optional, single">0:1</span>
+                    </p>
+                  </td>
+                  <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
+                    <p class="tableblock">
+                      <em>xs:boolean</em>
+                    </p>
+                  </td>
+                  <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
+                    <p class="tableblock darkbrown">Allows to flag if the VehicleJourney is a dead run, so it is clear that only there is no expectation of an associated service to it. +v2.3</p>
                   </td>
                 </tr>
                 <tr>
@@ -141284,7 +141384,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-24.9" title="local-type: typedef-24.9">local-type: typedef-24.9</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-62.9" title="local-type: typedef-62.9">local-type: typedef-62.9</a>
                       </em>
                     </p>
                   </td>
@@ -141462,7 +141562,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-24.8" title="local-type: typedef-24.8">local-type: typedef-24.8</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-62.8" title="local-type: typedef-62.8">local-type: typedef-62.8</a>
                       </em>
                     </p>
                   </td>
@@ -141599,7 +141699,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-24.9" title="local-type: typedef-24.9">local-type: typedef-24.9</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-62.9" title="local-type: typedef-62.9">local-type: typedef-62.9</a>
                       </em>
                     </p>
                   </td>
@@ -142249,7 +142349,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-24.9" title="local-type: typedef-24.9">local-type: typedef-24.9</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-62.9" title="local-type: typedef-62.9">local-type: typedef-62.9</a>
                       </em>
                     </p>
                   </td>
@@ -142427,7 +142527,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-24.8" title="local-type: typedef-24.8">local-type: typedef-24.8</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-62.8" title="local-type: typedef-62.8">local-type: typedef-62.8</a>
                       </em>
                     </p>
                   </td>
@@ -142451,7 +142551,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-24.6" title="local-type: typedef-24.6">local-type: typedef-24.6</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-62.6" title="local-type: typedef-62.6">local-type: typedef-62.6</a>
                       </em>
                     </p>
                   </td>
@@ -143612,7 +143712,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-24.1" title="local-type: typedef-24.1">local-type: typedef-24.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-62.1" title="local-type: typedef-62.1">local-type: typedef-62.1</a>
                       </em>
                     </p>
                   </td>
@@ -146631,7 +146731,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-24.1" title="local-type: typedef-24.1">local-type: typedef-24.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-62.1" title="local-type: typedef-62.1">local-type: typedef-62.1</a>
                       </em>
                     </p>
                   </td>
@@ -148022,7 +148122,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-24.9" title="local-type: typedef-24.9">local-type: typedef-24.9</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-62.9" title="local-type: typedef-62.9">local-type: typedef-62.9</a>
                       </em>
                     </p>
                   </td>
@@ -148200,7 +148300,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-24.8" title="local-type: typedef-24.8">local-type: typedef-24.8</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-62.8" title="local-type: typedef-62.8">local-type: typedef-62.8</a>
                       </em>
                     </p>
                   </td>
@@ -148633,7 +148733,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-24.7" title="local-type: typedef-24.7">local-type: typedef-24.7</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-62.7" title="local-type: typedef-62.7">local-type: typedef-62.7</a>
                       </em>
                     </p>
                   </td>
@@ -148881,7 +148981,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-24.9" title="local-type: typedef-24.9">local-type: typedef-24.9</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-62.9" title="local-type: typedef-62.9">local-type: typedef-62.9</a>
                       </em>
                     </p>
                   </td>
@@ -149059,7 +149159,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-24.8" title="local-type: typedef-24.8">local-type: typedef-24.8</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-62.8" title="local-type: typedef-62.8">local-type: typedef-62.8</a>
                       </em>
                     </p>
                   </td>
@@ -149125,7 +149225,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-24.5" title="local-type: typedef-24.5">local-type: typedef-24.5</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-62.5" title="local-type: typedef-62.5">local-type: typedef-62.5</a>
                       </em>
                     </p>
                   </td>
@@ -149979,8 +150079,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-24.2">
-          <h3>20.126. The complex type <code>group[siri:JourneyFormationGroup]/TrainElements#complexType (typedef-24.2)</code>
+        <div class="sect2" id="local-type.typedef-62.2">
+          <h3>20.126. The complex type <code>group[siri:JourneyFormationGroup]/TrainElements#complexType (typedef-62.2)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -150000,7 +150100,7 @@
                       <br/>
                       <code>  /TrainElements #complexType</code>
                       <br/>
-                      <code>  (typedef-24.2)</code>
+                      <code>  (typedef-62.2)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -150087,8 +150187,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-24.3">
-          <h3>20.127. The complex type <code>group[siri:JourneyFormationGroup]/Trains#complexType (typedef-24.3)</code>
+        <div class="sect2" id="local-type.typedef-62.3">
+          <h3>20.127. The complex type <code>group[siri:JourneyFormationGroup]/Trains#complexType (typedef-62.3)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -150108,7 +150208,7 @@
                       <br/>
                       <code>  /Trains #complexType</code>
                       <br/>
-                      <code>  (typedef-24.3)</code>
+                      <code>  (typedef-62.3)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -150195,8 +150295,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-24.4">
-          <h3>20.128. The complex type <code>group[siri:JourneyFormationGroup]/CompoundTrains#complexType (typedef-24.4)</code>
+        <div class="sect2" id="local-type.typedef-62.4">
+          <h3>20.128. The complex type <code>group[siri:JourneyFormationGroup]/CompoundTrains#complexType (typedef-62.4)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -150216,7 +150316,7 @@
                       <br/>
                       <code>  /CompoundTrains #complexType</code>
                       <br/>
-                      <code>  (typedef-24.4)</code>
+                      <code>  (typedef-62.4)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -150303,8 +150403,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-24.1">
-          <h3>20.129. The complex type <code>group[siri:JourneyRelationInfoGroup]/JourneyParts#complexType (typedef-24.1)</code>
+        <div class="sect2" id="local-type.typedef-62.1">
+          <h3>20.129. The complex type <code>group[siri:JourneyRelationInfoGroup]/JourneyParts#complexType (typedef-62.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -150324,7 +150424,7 @@
                       <br/>
                       <code>  /JourneyParts #complexType</code>
                       <br/>
-                      <code>  (typedef-24.1)</code>
+                      <code>  (typedef-62.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -150366,8 +150466,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-24.5">
-          <h3>20.130. The complex type <code>group[siri:TrainGroup]/TrainComponents#complexType (typedef-24.5)</code>
+        <div class="sect2" id="local-type.typedef-62.5">
+          <h3>20.130. The complex type <code>group[siri:TrainGroup]/TrainComponents#complexType (typedef-62.5)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -150387,7 +150487,7 @@
                       <br/>
                       <code>  /TrainComponents #complexType</code>
                       <br/>
-                      <code>  (typedef-24.5)</code>
+                      <code>  (typedef-62.5)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -150474,8 +150574,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-24.7">
-          <h3>20.131. The complex type <code>group[siri:TrainInCompoundTrainGroup]/Passages#complexType (typedef-24.7)</code>
+        <div class="sect2" id="local-type.typedef-62.7">
+          <h3>20.131. The complex type <code>group[siri:TrainInCompoundTrainGroup]/Passages#complexType (typedef-62.7)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -150495,7 +150595,7 @@
                       <br/>
                       <code>  /Passages #complexType</code>
                       <br/>
-                      <code>  (typedef-24.7)</code>
+                      <code>  (typedef-62.7)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -150537,8 +150637,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-24.9">
-          <h3>20.132. The complex type <code>group[siri:VehicleTypePropertiesGroup]/MaximumPassengerCapacities#complexType (typedef-24.9)</code>
+        <div class="sect2" id="local-type.typedef-62.9">
+          <h3>20.132. The complex type <code>group[siri:VehicleTypePropertiesGroup]/MaximumPassengerCapacities#complexType (typedef-62.9)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -150558,7 +150658,7 @@
                       <br/>
                       <code>  /MaximumPassengerCapacities #complexType</code>
                       <br/>
-                      <code>  (typedef-24.9)</code>
+                      <code>  (typedef-62.9)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -150600,8 +150700,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-24.8">
-          <h3>20.133. The complex type <code>group[siri:VehicleTypeGroup]/Facilities#complexType (typedef-24.8)</code>
+        <div class="sect2" id="local-type.typedef-62.8">
+          <h3>20.133. The complex type <code>group[siri:VehicleTypeGroup]/Facilities#complexType (typedef-62.8)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -150621,7 +150721,7 @@
                       <br/>
                       <code>  /Facilities #complexType</code>
                       <br/>
-                      <code>  (typedef-24.8)</code>
+                      <code>  (typedef-62.8)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -150741,8 +150841,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-24.9">
-          <h3>20.134. The complex type <code>group[siri:VehicleTypePropertiesGroup]/MaximumPassengerCapacities#complexType (typedef-24.9)</code>
+        <div class="sect2" id="local-type.typedef-62.9">
+          <h3>20.134. The complex type <code>group[siri:VehicleTypePropertiesGroup]/MaximumPassengerCapacities#complexType (typedef-62.9)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -150762,7 +150862,7 @@
                       <br/>
                       <code>  /MaximumPassengerCapacities #complexType</code>
                       <br/>
-                      <code>  (typedef-24.9)</code>
+                      <code>  (typedef-62.9)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -150804,8 +150904,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-24.9">
-          <h3>20.135. The complex type <code>group[siri:VehicleTypePropertiesGroup]/MaximumPassengerCapacities#complexType (typedef-24.9)</code>
+        <div class="sect2" id="local-type.typedef-62.9">
+          <h3>20.135. The complex type <code>group[siri:VehicleTypePropertiesGroup]/MaximumPassengerCapacities#complexType (typedef-62.9)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -150825,7 +150925,7 @@
                       <br/>
                       <code>  /MaximumPassengerCapacities #complexType</code>
                       <br/>
-                      <code>  (typedef-24.9)</code>
+                      <code>  (typedef-62.9)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -150867,8 +150967,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-24.8">
-          <h3>20.136. The complex type <code>group[siri:VehicleTypeGroup]/Facilities#complexType (typedef-24.8)</code>
+        <div class="sect2" id="local-type.typedef-62.8">
+          <h3>20.136. The complex type <code>group[siri:VehicleTypeGroup]/Facilities#complexType (typedef-62.8)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -150888,7 +150988,7 @@
                       <br/>
                       <code>  /Facilities #complexType</code>
                       <br/>
-                      <code>  (typedef-24.8)</code>
+                      <code>  (typedef-62.8)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -151008,8 +151108,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-24.6">
-          <h3>20.137. The complex type <code>complexType[siri:CompoundTrainStructure]/TrainsInCompoundTrain#complexType (typedef-24.6)</code>
+        <div class="sect2" id="local-type.typedef-62.6">
+          <h3>20.137. The complex type <code>complexType[siri:CompoundTrainStructure]/TrainsInCompoundTrain#complexType (typedef-62.6)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -151029,7 +151129,7 @@
                       <br/>
                       <code>  /TrainsInCompoundTrain #complexType</code>
                       <br/>
-                      <code>  (typedef-24.6)</code>
+                      <code>  (typedef-62.6)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -151116,8 +151216,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-24.1">
-          <h3>20.138. The complex type <code>group[siri:JourneyRelationInfoGroup]/JourneyParts#complexType (typedef-24.1)</code>
+        <div class="sect2" id="local-type.typedef-62.1">
+          <h3>20.138. The complex type <code>group[siri:JourneyRelationInfoGroup]/JourneyParts#complexType (typedef-62.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -151137,7 +151237,7 @@
                       <br/>
                       <code>  /JourneyParts #complexType</code>
                       <br/>
-                      <code>  (typedef-24.1)</code>
+                      <code>  (typedef-62.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -151179,8 +151279,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-24.1">
-          <h3>20.139. The complex type <code>group[siri:JourneyRelationInfoGroup]/JourneyParts#complexType (typedef-24.1)</code>
+        <div class="sect2" id="local-type.typedef-62.1">
+          <h3>20.139. The complex type <code>group[siri:JourneyRelationInfoGroup]/JourneyParts#complexType (typedef-62.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -151200,7 +151300,7 @@
                       <br/>
                       <code>  /JourneyParts #complexType</code>
                       <br/>
-                      <code>  (typedef-24.1)</code>
+                      <code>  (typedef-62.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -151242,8 +151342,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-24.9">
-          <h3>20.140. The complex type <code>group[siri:VehicleTypePropertiesGroup]/MaximumPassengerCapacities#complexType (typedef-24.9)</code>
+        <div class="sect2" id="local-type.typedef-62.9">
+          <h3>20.140. The complex type <code>group[siri:VehicleTypePropertiesGroup]/MaximumPassengerCapacities#complexType (typedef-62.9)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -151263,7 +151363,7 @@
                       <br/>
                       <code>  /MaximumPassengerCapacities #complexType</code>
                       <br/>
-                      <code>  (typedef-24.9)</code>
+                      <code>  (typedef-62.9)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -151305,8 +151405,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-24.8">
-          <h3>20.141. The complex type <code>group[siri:VehicleTypeGroup]/Facilities#complexType (typedef-24.8)</code>
+        <div class="sect2" id="local-type.typedef-62.8">
+          <h3>20.141. The complex type <code>group[siri:VehicleTypeGroup]/Facilities#complexType (typedef-62.8)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -151326,7 +151426,7 @@
                       <br/>
                       <code>  /Facilities #complexType</code>
                       <br/>
-                      <code>  (typedef-24.8)</code>
+                      <code>  (typedef-62.8)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -151446,8 +151546,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-24.7">
-          <h3>20.142. The complex type <code>group[siri:TrainInCompoundTrainGroup]/Passages#complexType (typedef-24.7)</code>
+        <div class="sect2" id="local-type.typedef-62.7">
+          <h3>20.142. The complex type <code>group[siri:TrainInCompoundTrainGroup]/Passages#complexType (typedef-62.7)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -151467,7 +151567,7 @@
                       <br/>
                       <code>  /Passages #complexType</code>
                       <br/>
-                      <code>  (typedef-24.7)</code>
+                      <code>  (typedef-62.7)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -151509,8 +151609,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-24.9">
-          <h3>20.143. The complex type <code>group[siri:VehicleTypePropertiesGroup]/MaximumPassengerCapacities#complexType (typedef-24.9)</code>
+        <div class="sect2" id="local-type.typedef-62.9">
+          <h3>20.143. The complex type <code>group[siri:VehicleTypePropertiesGroup]/MaximumPassengerCapacities#complexType (typedef-62.9)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -151530,7 +151630,7 @@
                       <br/>
                       <code>  /MaximumPassengerCapacities #complexType</code>
                       <br/>
-                      <code>  (typedef-24.9)</code>
+                      <code>  (typedef-62.9)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -151572,8 +151672,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-24.8">
-          <h3>20.144. The complex type <code>group[siri:VehicleTypeGroup]/Facilities#complexType (typedef-24.8)</code>
+        <div class="sect2" id="local-type.typedef-62.8">
+          <h3>20.144. The complex type <code>group[siri:VehicleTypeGroup]/Facilities#complexType (typedef-62.8)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -151593,7 +151693,7 @@
                       <br/>
                       <code>  /Facilities #complexType</code>
                       <br/>
-                      <code>  (typedef-24.8)</code>
+                      <code>  (typedef-62.8)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -151713,8 +151813,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-24.5">
-          <h3>20.145. The complex type <code>group[siri:TrainGroup]/TrainComponents#complexType (typedef-24.5)</code>
+        <div class="sect2" id="local-type.typedef-62.5">
+          <h3>20.145. The complex type <code>group[siri:TrainGroup]/TrainComponents#complexType (typedef-62.5)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -151734,7 +151834,7 @@
                       <br/>
                       <code>  /TrainComponents #complexType</code>
                       <br/>
-                      <code>  (typedef-24.5)</code>
+                      <code>  (typedef-62.5)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -156891,7 +156991,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-61.1" title="local-type: typedef-61.1">local-type: typedef-61.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-44.1" title="local-type: typedef-44.1">local-type: typedef-44.1</a>
                       </em>
                     </p>
                   </td>
@@ -156925,7 +157025,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-2.2" title="local-type: typedef-2.2">local-type: typedef-2.2</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-65.2" title="local-type: typedef-65.2">local-type: typedef-65.2</a>
                       </em>
                     </p>
                   </td>
@@ -156954,7 +157054,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-2.1" title="local-type: typedef-2.1">local-type: typedef-2.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-65.1" title="local-type: typedef-65.1">local-type: typedef-65.1</a>
                       </em>
                     </p>
                   </td>
@@ -156983,7 +157083,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-2.3" title="local-type: typedef-2.3">local-type: typedef-2.3</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-65.3" title="local-type: typedef-65.3">local-type: typedef-65.3</a>
                       </em>
                     </p>
                   </td>
@@ -157535,8 +157635,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-2.3">
-          <h3>22.31. The complex type <code>element[siri:ConnectionLinkPermissions]#complexType (typedef-2.3)</code>
+        <div class="sect2" id="local-type.typedef-65.3">
+          <h3>22.31. The complex type <code>element[siri:ConnectionLinkPermissions]#complexType (typedef-65.3)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -157556,7 +157656,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-2.3)</code>
+                      <code>  (typedef-65.3)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -157641,8 +157741,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-2.1">
-          <h3>22.32. The complex type <code>element[siri:LinePermissions]#complexType (typedef-2.1)</code>
+        <div class="sect2" id="local-type.typedef-65.1">
+          <h3>22.32. The complex type <code>element[siri:LinePermissions]#complexType (typedef-65.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -157662,7 +157762,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-2.1)</code>
+                      <code>  (typedef-65.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -157747,8 +157847,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-2.2">
-          <h3>22.33. The complex type <code>element[siri:OperatorPermissions]#complexType (typedef-2.2)</code>
+        <div class="sect2" id="local-type.typedef-65.2">
+          <h3>22.33. The complex type <code>element[siri:OperatorPermissions]#complexType (typedef-65.2)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -157768,7 +157868,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-2.2)</code>
+                      <code>  (typedef-65.2)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -157853,8 +157953,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-61.1">
-          <h3>22.34. The complex type <code>complexType[siri:AbstractPermissionStructure]/GeneralCapabilities#complexType (typedef-61.1)</code>
+        <div class="sect2" id="local-type.typedef-44.1">
+          <h3>22.34. The complex type <code>complexType[siri:AbstractPermissionStructure]/GeneralCapabilities#complexType (typedef-44.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -157874,7 +157974,7 @@
                       <br/>
                       <code>  /GeneralCapabilities #complexType</code>
                       <br/>
-                      <code>  (typedef-61.1)</code>
+                      <code>  (typedef-44.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -157942,8 +158042,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-2.2">
-          <h3>22.35. The complex type <code>element[siri:OperatorPermissions]#complexType (typedef-2.2)</code>
+        <div class="sect2" id="local-type.typedef-65.2">
+          <h3>22.35. The complex type <code>element[siri:OperatorPermissions]#complexType (typedef-65.2)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -157963,7 +158063,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-2.2)</code>
+                      <code>  (typedef-65.2)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -158048,8 +158148,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-2.1">
-          <h3>22.36. The complex type <code>element[siri:LinePermissions]#complexType (typedef-2.1)</code>
+        <div class="sect2" id="local-type.typedef-65.1">
+          <h3>22.36. The complex type <code>element[siri:LinePermissions]#complexType (typedef-65.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -158069,7 +158169,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-2.1)</code>
+                      <code>  (typedef-65.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -158154,8 +158254,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-2.3">
-          <h3>22.37. The complex type <code>element[siri:ConnectionLinkPermissions]#complexType (typedef-2.3)</code>
+        <div class="sect2" id="local-type.typedef-65.3">
+          <h3>22.37. The complex type <code>element[siri:ConnectionLinkPermissions]#complexType (typedef-65.3)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -158175,7 +158275,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-2.3)</code>
+                      <code>  (typedef-65.3)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -164388,7 +164488,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-8.6" title="local-type: typedef-8.6">local-type: typedef-8.6</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-60.6" title="local-type: typedef-60.6">local-type: typedef-60.6</a>
                       </em>
                     </p>
                   </td>
@@ -164409,7 +164509,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-8.7" title="local-type: typedef-8.7">local-type: typedef-8.7</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-60.7" title="local-type: typedef-60.7">local-type: typedef-60.7</a>
                       </em>
                     </p>
                   </td>
@@ -164433,7 +164533,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-24.2" title="local-type: typedef-24.2">local-type: typedef-24.2</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-62.2" title="local-type: typedef-62.2">local-type: typedef-62.2</a>
                       </em>
                     </p>
                   </td>
@@ -164454,7 +164554,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-24.3" title="local-type: typedef-24.3">local-type: typedef-24.3</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-62.3" title="local-type: typedef-62.3">local-type: typedef-62.3</a>
                       </em>
                     </p>
                   </td>
@@ -164475,7 +164575,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-24.4" title="local-type: typedef-24.4">local-type: typedef-24.4</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-62.4" title="local-type: typedef-62.4">local-type: typedef-62.4</a>
                       </em>
                     </p>
                   </td>
@@ -167198,7 +167298,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-8.1" title="local-type: typedef-8.1">local-type: typedef-8.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-60.1" title="local-type: typedef-60.1">local-type: typedef-60.1</a>
                       </em>
                     </p>
                   </td>
@@ -167219,7 +167319,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-8.2" title="local-type: typedef-8.2">local-type: typedef-8.2</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-60.2" title="local-type: typedef-60.2">local-type: typedef-60.2</a>
                       </em>
                     </p>
                   </td>
@@ -167240,7 +167340,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-8.3" title="local-type: typedef-8.3">local-type: typedef-8.3</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-60.3" title="local-type: typedef-60.3">local-type: typedef-60.3</a>
                       </em>
                     </p>
                   </td>
@@ -168345,7 +168445,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-8.4" title="local-type: typedef-8.4">local-type: typedef-8.4</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-60.4" title="local-type: typedef-60.4">local-type: typedef-60.4</a>
                       </em>
                     </p>
                   </td>
@@ -168366,7 +168466,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-8.5" title="local-type: typedef-8.5">local-type: typedef-8.5</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-60.5" title="local-type: typedef-60.5">local-type: typedef-60.5</a>
                       </em>
                     </p>
                   </td>
@@ -168390,7 +168490,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-24.2" title="local-type: typedef-24.2">local-type: typedef-24.2</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-62.2" title="local-type: typedef-62.2">local-type: typedef-62.2</a>
                       </em>
                     </p>
                   </td>
@@ -168411,7 +168511,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-24.3" title="local-type: typedef-24.3">local-type: typedef-24.3</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-62.3" title="local-type: typedef-62.3">local-type: typedef-62.3</a>
                       </em>
                     </p>
                   </td>
@@ -168432,7 +168532,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-24.4" title="local-type: typedef-24.4">local-type: typedef-24.4</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-62.4" title="local-type: typedef-62.4">local-type: typedef-62.4</a>
                       </em>
                     </p>
                   </td>
@@ -170907,7 +171007,7 @@
                   </td>
                 </tr>
                 <tr>
-                  <td colspan="1" rowspan="4" class="tableblock halign-left valign-top">
+                  <td colspan="1" rowspan="5" class="tableblock halign-left valign-top">
                     <a shape="rect" href="#group.siri:JourneyInfoGroup" title="siri:JourneyInfoGroup">siri:JourneyInfoGroup</a>
                   </td>
                   <td colspan="2" rowspan="1" class="tableblock halign-left valign-top">
@@ -170928,6 +171028,26 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock darkbrown">For train services with named journeys. Train name, e.g. “West Coast Express”. If omitted: No train name. Inherited property. (Unbounded since SIRI 2.0)</p>
+                  </td>
+                </tr>
+                <tr>
+                  <td colspan="2" rowspan="1" class="tableblock halign-left valign-top">
+                    <p class="tableblock">
+                      <code>siri:DeadRun</code>
+                    </p>
+                  </td>
+                  <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
+                    <p class="tableblock">
+                      <span title="optional, single">0:1</span>
+                    </p>
+                  </td>
+                  <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
+                    <p class="tableblock">
+                      <em>xs:boolean</em>
+                    </p>
+                  </td>
+                  <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
+                    <p class="tableblock darkbrown">Allows to flag if the VehicleJourney is a dead run, so it is clear that only there is no expectation of an associated service to it. +v2.3</p>
                   </td>
                 </tr>
                 <tr>
@@ -171775,7 +171895,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-8.4" title="local-type: typedef-8.4">local-type: typedef-8.4</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-60.4" title="local-type: typedef-60.4">local-type: typedef-60.4</a>
                       </em>
                     </p>
                   </td>
@@ -171796,7 +171916,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-8.5" title="local-type: typedef-8.5">local-type: typedef-8.5</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-60.5" title="local-type: typedef-60.5">local-type: typedef-60.5</a>
                       </em>
                     </p>
                   </td>
@@ -171820,7 +171940,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-24.2" title="local-type: typedef-24.2">local-type: typedef-24.2</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-62.2" title="local-type: typedef-62.2">local-type: typedef-62.2</a>
                       </em>
                     </p>
                   </td>
@@ -171841,7 +171961,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-24.3" title="local-type: typedef-24.3">local-type: typedef-24.3</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-62.3" title="local-type: typedef-62.3">local-type: typedef-62.3</a>
                       </em>
                     </p>
                   </td>
@@ -171862,7 +171982,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-24.4" title="local-type: typedef-24.4">local-type: typedef-24.4</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-62.4" title="local-type: typedef-62.4">local-type: typedef-62.4</a>
                       </em>
                     </p>
                   </td>
@@ -172524,8 +172644,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-8.6">
-          <h3>24.23. The complex type <code>group[siri:DatedTrainOperationalInfoGroup]/TrainNumbers#complexType (typedef-8.6)</code>
+        <div class="sect2" id="local-type.typedef-60.6">
+          <h3>24.23. The complex type <code>group[siri:DatedTrainOperationalInfoGroup]/TrainNumbers#complexType (typedef-60.6)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -172545,7 +172665,7 @@
                       <br/>
                       <code>  /TrainNumbers #complexType</code>
                       <br/>
-                      <code>  (typedef-8.6)</code>
+                      <code>  (typedef-60.6)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -172587,8 +172707,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-8.7">
-          <h3>24.24. The complex type <code>group[siri:DatedTrainOperationalInfoGroup]/JourneyParts#complexType (typedef-8.7)</code>
+        <div class="sect2" id="local-type.typedef-60.7">
+          <h3>24.24. The complex type <code>group[siri:DatedTrainOperationalInfoGroup]/JourneyParts#complexType (typedef-60.7)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -172608,7 +172728,7 @@
                       <br/>
                       <code>  /JourneyParts #complexType</code>
                       <br/>
-                      <code>  (typedef-8.7)</code>
+                      <code>  (typedef-60.7)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -172650,8 +172770,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-24.2">
-          <h3>24.25. The complex type <code>group[siri:JourneyFormationGroup]/TrainElements#complexType (typedef-24.2)</code>
+        <div class="sect2" id="local-type.typedef-62.2">
+          <h3>24.25. The complex type <code>group[siri:JourneyFormationGroup]/TrainElements#complexType (typedef-62.2)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -172671,7 +172791,7 @@
                       <br/>
                       <code>  /TrainElements #complexType</code>
                       <br/>
-                      <code>  (typedef-24.2)</code>
+                      <code>  (typedef-62.2)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -172758,8 +172878,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-24.3">
-          <h3>24.26. The complex type <code>group[siri:JourneyFormationGroup]/Trains#complexType (typedef-24.3)</code>
+        <div class="sect2" id="local-type.typedef-62.3">
+          <h3>24.26. The complex type <code>group[siri:JourneyFormationGroup]/Trains#complexType (typedef-62.3)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -172779,7 +172899,7 @@
                       <br/>
                       <code>  /Trains #complexType</code>
                       <br/>
-                      <code>  (typedef-24.3)</code>
+                      <code>  (typedef-62.3)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -172866,8 +172986,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-24.4">
-          <h3>24.27. The complex type <code>group[siri:JourneyFormationGroup]/CompoundTrains#complexType (typedef-24.4)</code>
+        <div class="sect2" id="local-type.typedef-62.4">
+          <h3>24.27. The complex type <code>group[siri:JourneyFormationGroup]/CompoundTrains#complexType (typedef-62.4)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -172887,7 +173007,7 @@
                       <br/>
                       <code>  /CompoundTrains #complexType</code>
                       <br/>
-                      <code>  (typedef-24.4)</code>
+                      <code>  (typedef-62.4)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -172974,8 +173094,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-8.1">
-          <h3>24.28. The complex type <code>group[siri:ServicePointsGroup]/Origin#complexType (typedef-8.1)</code>
+        <div class="sect2" id="local-type.typedef-60.1">
+          <h3>24.28. The complex type <code>group[siri:ServicePointsGroup]/Origin#complexType (typedef-60.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -172995,7 +173115,7 @@
                       <br/>
                       <code>  /Origin #complexType</code>
                       <br/>
-                      <code>  (typedef-8.1)</code>
+                      <code>  (typedef-60.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -173059,8 +173179,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-8.2">
-          <h3>24.29. The complex type <code>group[siri:ServicePointsGroup]/Via#complexType (typedef-8.2)</code>
+        <div class="sect2" id="local-type.typedef-60.2">
+          <h3>24.29. The complex type <code>group[siri:ServicePointsGroup]/Via#complexType (typedef-60.2)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -173080,7 +173200,7 @@
                       <br/>
                       <code>  /Via #complexType</code>
                       <br/>
-                      <code>  (typedef-8.2)</code>
+                      <code>  (typedef-60.2)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -173167,8 +173287,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-8.3">
-          <h3>24.30. The complex type <code>group[siri:ServicePointsGroup]/Destination#complexType (typedef-8.3)</code>
+        <div class="sect2" id="local-type.typedef-60.3">
+          <h3>24.30. The complex type <code>group[siri:ServicePointsGroup]/Destination#complexType (typedef-60.3)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -173188,7 +173308,7 @@
                       <br/>
                       <code>  /Destination #complexType</code>
                       <br/>
-                      <code>  (typedef-8.3)</code>
+                      <code>  (typedef-60.3)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -173252,8 +173372,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-8.4">
-          <h3>24.31. The complex type <code>group[siri:TrainOperationalInfoGroup]/TrainNumbers#complexType (typedef-8.4)</code>
+        <div class="sect2" id="local-type.typedef-60.4">
+          <h3>24.31. The complex type <code>group[siri:TrainOperationalInfoGroup]/TrainNumbers#complexType (typedef-60.4)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -173273,7 +173393,7 @@
                       <br/>
                       <code>  /TrainNumbers #complexType</code>
                       <br/>
-                      <code>  (typedef-8.4)</code>
+                      <code>  (typedef-60.4)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -173315,8 +173435,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-8.5">
-          <h3>24.32. The complex type <code>group[siri:TrainOperationalInfoGroup]/JourneyParts#complexType (typedef-8.5)</code>
+        <div class="sect2" id="local-type.typedef-60.5">
+          <h3>24.32. The complex type <code>group[siri:TrainOperationalInfoGroup]/JourneyParts#complexType (typedef-60.5)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -173336,7 +173456,7 @@
                       <br/>
                       <code>  /JourneyParts #complexType</code>
                       <br/>
-                      <code>  (typedef-8.5)</code>
+                      <code>  (typedef-60.5)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -173378,8 +173498,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-24.2">
-          <h3>24.33. The complex type <code>group[siri:JourneyFormationGroup]/TrainElements#complexType (typedef-24.2)</code>
+        <div class="sect2" id="local-type.typedef-62.2">
+          <h3>24.33. The complex type <code>group[siri:JourneyFormationGroup]/TrainElements#complexType (typedef-62.2)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -173399,7 +173519,7 @@
                       <br/>
                       <code>  /TrainElements #complexType</code>
                       <br/>
-                      <code>  (typedef-24.2)</code>
+                      <code>  (typedef-62.2)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -173486,8 +173606,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-24.3">
-          <h3>24.34. The complex type <code>group[siri:JourneyFormationGroup]/Trains#complexType (typedef-24.3)</code>
+        <div class="sect2" id="local-type.typedef-62.3">
+          <h3>24.34. The complex type <code>group[siri:JourneyFormationGroup]/Trains#complexType (typedef-62.3)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -173507,7 +173627,7 @@
                       <br/>
                       <code>  /Trains #complexType</code>
                       <br/>
-                      <code>  (typedef-24.3)</code>
+                      <code>  (typedef-62.3)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -173594,8 +173714,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-24.4">
-          <h3>24.35. The complex type <code>group[siri:JourneyFormationGroup]/CompoundTrains#complexType (typedef-24.4)</code>
+        <div class="sect2" id="local-type.typedef-62.4">
+          <h3>24.35. The complex type <code>group[siri:JourneyFormationGroup]/CompoundTrains#complexType (typedef-62.4)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -173615,7 +173735,7 @@
                       <br/>
                       <code>  /CompoundTrains #complexType</code>
                       <br/>
-                      <code>  (typedef-24.4)</code>
+                      <code>  (typedef-62.4)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -173702,8 +173822,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-8.4">
-          <h3>24.36. The complex type <code>group[siri:TrainOperationalInfoGroup]/TrainNumbers#complexType (typedef-8.4)</code>
+        <div class="sect2" id="local-type.typedef-60.4">
+          <h3>24.36. The complex type <code>group[siri:TrainOperationalInfoGroup]/TrainNumbers#complexType (typedef-60.4)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -173723,7 +173843,7 @@
                       <br/>
                       <code>  /TrainNumbers #complexType</code>
                       <br/>
-                      <code>  (typedef-8.4)</code>
+                      <code>  (typedef-60.4)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -173765,8 +173885,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-8.5">
-          <h3>24.37. The complex type <code>group[siri:TrainOperationalInfoGroup]/JourneyParts#complexType (typedef-8.5)</code>
+        <div class="sect2" id="local-type.typedef-60.5">
+          <h3>24.37. The complex type <code>group[siri:TrainOperationalInfoGroup]/JourneyParts#complexType (typedef-60.5)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -173786,7 +173906,7 @@
                       <br/>
                       <code>  /JourneyParts #complexType</code>
                       <br/>
-                      <code>  (typedef-8.5)</code>
+                      <code>  (typedef-60.5)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -173828,8 +173948,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-24.2">
-          <h3>24.38. The complex type <code>group[siri:JourneyFormationGroup]/TrainElements#complexType (typedef-24.2)</code>
+        <div class="sect2" id="local-type.typedef-62.2">
+          <h3>24.38. The complex type <code>group[siri:JourneyFormationGroup]/TrainElements#complexType (typedef-62.2)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -173849,7 +173969,7 @@
                       <br/>
                       <code>  /TrainElements #complexType</code>
                       <br/>
-                      <code>  (typedef-24.2)</code>
+                      <code>  (typedef-62.2)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -173936,8 +174056,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-24.3">
-          <h3>24.39. The complex type <code>group[siri:JourneyFormationGroup]/Trains#complexType (typedef-24.3)</code>
+        <div class="sect2" id="local-type.typedef-62.3">
+          <h3>24.39. The complex type <code>group[siri:JourneyFormationGroup]/Trains#complexType (typedef-62.3)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -173957,7 +174077,7 @@
                       <br/>
                       <code>  /Trains #complexType</code>
                       <br/>
-                      <code>  (typedef-24.3)</code>
+                      <code>  (typedef-62.3)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -174044,8 +174164,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-24.4">
-          <h3>24.40. The complex type <code>group[siri:JourneyFormationGroup]/CompoundTrains#complexType (typedef-24.4)</code>
+        <div class="sect2" id="local-type.typedef-62.4">
+          <h3>24.40. The complex type <code>group[siri:JourneyFormationGroup]/CompoundTrains#complexType (typedef-62.4)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -174065,7 +174185,7 @@
                       <br/>
                       <code>  /CompoundTrains #complexType</code>
                       <br/>
-                      <code>  (typedef-24.4)</code>
+                      <code>  (typedef-62.4)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -178775,12 +178895,12 @@
                 </tr>
                 <tr>
                   <td colspan="1" rowspan="2" class="tableblock halign-left valign-top">
-                    <p id="local-type.typedef-11.3" class="tableblock">
+                    <p id="local-type.typedef-64.3" class="tableblock">
                       <code>group[siri:ClassifierGroup]</code>
                       <br/>
                       <code>  /ScopeType #simpleType</code>
                       <br/>
-                      <code>  (typedef-11.3)</code>
+                      <code>  (typedef-64.3)</code>
                     </p>
                   </td>
                   <td colspan="2" rowspan="1" class="tableblock halign-left valign-top">
@@ -178961,12 +179081,12 @@
                 </tr>
                 <tr>
                   <td colspan="1" rowspan="2" class="tableblock halign-left valign-top">
-                    <p id="local-type.typedef-11.1" class="tableblock">
+                    <p id="local-type.typedef-64.1" class="tableblock">
                       <code>group[siri:StatusGroup]</code>
                       <br/>
                       <code>  /Verification #simpleType</code>
                       <br/>
-                      <code>  (typedef-11.1)</code>
+                      <code>  (typedef-64.1)</code>
                     </p>
                   </td>
                   <td colspan="2" rowspan="1" class="tableblock halign-left valign-top">
@@ -179027,12 +179147,12 @@
                 </tr>
                 <tr>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
-                    <p id="local-type.typedef-36.1" class="tableblock">
+                    <p id="local-type.typedef-39.1" class="tableblock">
                       <code>attribute[lang]</code>
                       <br/>
                       <code>  #simpleType</code>
                       <br/>
-                      <code>  (typedef-36.1)</code>
+                      <code>  (typedef-39.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -179660,7 +179780,7 @@
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
                       <em>
-                        <a shape="rect" href="/home/runner/work/SIRI/SIRI/docs/generated/contab/siri.enum-dict.html#local-enum.typedef-11.3" title="local-type: typedef-11.3">local-type: typedef-11.3</a>
+                        <a shape="rect" href="/home/runner/work/SIRI/SIRI/docs/generated/contab/siri.enum-dict.html#local-enum.typedef-64.3" title="local-type: typedef-64.3">local-type: typedef-64.3</a>
                       </em>
                     </p>
                   </td>
@@ -179744,7 +179864,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-11.4" title="local-type: typedef-11.4">local-type: typedef-11.4</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-64.4" title="local-type: typedef-64.4">local-type: typedef-64.4</a>
                       </em>
                     </p>
                   </td>
@@ -180510,7 +180630,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-11.14" title="local-type: typedef-11.14">local-type: typedef-11.14</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-64.14" title="local-type: typedef-64.14">local-type: typedef-64.14</a>
                       </em>
                     </p>
                   </td>
@@ -180531,7 +180651,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-11.16" title="local-type: typedef-11.16">local-type: typedef-11.16</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-64.16" title="local-type: typedef-64.16">local-type: typedef-64.16</a>
                       </em>
                     </p>
                   </td>
@@ -180684,7 +180804,7 @@
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
                       <em>
-                        <a shape="rect" href="/home/runner/work/SIRI/SIRI/docs/generated/contab/siri.enum-dict.html#local-enum.typedef-11.1" title="local-type: typedef-11.1">local-type: typedef-11.1</a>
+                        <a shape="rect" href="/home/runner/work/SIRI/SIRI/docs/generated/contab/siri.enum-dict.html#local-enum.typedef-64.1" title="local-type: typedef-64.1">local-type: typedef-64.1</a>
                       </em>
                     </p>
                   </td>
@@ -180843,7 +180963,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-11.2" title="local-type: typedef-11.2">local-type: typedef-11.2</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-64.2" title="local-type: typedef-64.2">local-type: typedef-64.2</a>
                       </em>
                     </p>
                   </td>
@@ -181391,7 +181511,7 @@
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
                       <em>
-                        <a shape="rect" href="/home/runner/work/SIRI/SIRI/docs/generated/contab/siri.enum-dict.html#local-enum.typedef-11.3" title="local-type: typedef-11.3">local-type: typedef-11.3</a>
+                        <a shape="rect" href="/home/runner/work/SIRI/SIRI/docs/generated/contab/siri.enum-dict.html#local-enum.typedef-64.3" title="local-type: typedef-64.3">local-type: typedef-64.3</a>
                       </em>
                     </p>
                   </td>
@@ -181475,7 +181595,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-11.4" title="local-type: typedef-11.4">local-type: typedef-11.4</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-64.4" title="local-type: typedef-64.4">local-type: typedef-64.4</a>
                       </em>
                     </p>
                   </td>
@@ -181624,7 +181744,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-11.14" title="local-type: typedef-11.14">local-type: typedef-11.14</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-64.14" title="local-type: typedef-64.14">local-type: typedef-64.14</a>
                       </em>
                     </p>
                   </td>
@@ -181645,7 +181765,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-11.16" title="local-type: typedef-11.16">local-type: typedef-11.16</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-64.16" title="local-type: typedef-64.16">local-type: typedef-64.16</a>
                       </em>
                     </p>
                   </td>
@@ -182331,7 +182451,7 @@
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
                       <em>
-                        <a shape="rect" href="/home/runner/work/SIRI/SIRI/docs/generated/contab/siri.enum-dict.html#local-enum.typedef-11.1" title="local-type: typedef-11.1">local-type: typedef-11.1</a>
+                        <a shape="rect" href="/home/runner/work/SIRI/SIRI/docs/generated/contab/siri.enum-dict.html#local-enum.typedef-64.1" title="local-type: typedef-64.1">local-type: typedef-64.1</a>
                       </em>
                     </p>
                   </td>
@@ -182490,7 +182610,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-11.2" title="local-type: typedef-11.2">local-type: typedef-11.2</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-64.2" title="local-type: typedef-64.2">local-type: typedef-64.2</a>
                       </em>
                     </p>
                   </td>
@@ -183038,7 +183158,7 @@
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
                       <em>
-                        <a shape="rect" href="/home/runner/work/SIRI/SIRI/docs/generated/contab/siri.enum-dict.html#local-enum.typedef-11.3" title="local-type: typedef-11.3">local-type: typedef-11.3</a>
+                        <a shape="rect" href="/home/runner/work/SIRI/SIRI/docs/generated/contab/siri.enum-dict.html#local-enum.typedef-64.3" title="local-type: typedef-64.3">local-type: typedef-64.3</a>
                       </em>
                     </p>
                   </td>
@@ -183122,7 +183242,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-11.4" title="local-type: typedef-11.4">local-type: typedef-11.4</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-64.4" title="local-type: typedef-64.4">local-type: typedef-64.4</a>
                       </em>
                     </p>
                   </td>
@@ -183271,7 +183391,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-11.14" title="local-type: typedef-11.14">local-type: typedef-11.14</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-64.14" title="local-type: typedef-64.14">local-type: typedef-64.14</a>
                       </em>
                     </p>
                   </td>
@@ -183292,7 +183412,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-11.16" title="local-type: typedef-11.16">local-type: typedef-11.16</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-64.16" title="local-type: typedef-64.16">local-type: typedef-64.16</a>
                       </em>
                     </p>
                   </td>
@@ -183655,7 +183775,7 @@
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
                       <em>
-                        <a shape="rect" href="/home/runner/work/SIRI/SIRI/docs/generated/contab/siri.enum-dict.html#local-enum.typedef-11.1" title="local-type: typedef-11.1">local-type: typedef-11.1</a>
+                        <a shape="rect" href="/home/runner/work/SIRI/SIRI/docs/generated/contab/siri.enum-dict.html#local-enum.typedef-64.1" title="local-type: typedef-64.1">local-type: typedef-64.1</a>
                       </em>
                     </p>
                   </td>
@@ -183845,7 +183965,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-11.2" title="local-type: typedef-11.2">local-type: typedef-11.2</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-64.2" title="local-type: typedef-64.2">local-type: typedef-64.2</a>
                       </em>
                     </p>
                   </td>
@@ -184345,7 +184465,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-11.6" title="local-type: typedef-11.6">local-type: typedef-11.6</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-64.6" title="local-type: typedef-64.6">local-type: typedef-64.6</a>
                       </em>
                     </p>
                   </td>
@@ -184369,7 +184489,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-11.7" title="local-type: typedef-11.7">local-type: typedef-11.7</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-64.7" title="local-type: typedef-64.7">local-type: typedef-64.7</a>
                       </em>
                     </p>
                   </td>
@@ -184393,7 +184513,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-11.9" title="local-type: typedef-11.9">local-type: typedef-11.9</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-64.9" title="local-type: typedef-64.9">local-type: typedef-64.9</a>
                       </em>
                     </p>
                   </td>
@@ -184417,7 +184537,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-11.10" title="local-type: typedef-11.10">local-type: typedef-11.10</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-64.10" title="local-type: typedef-64.10">local-type: typedef-64.10</a>
                       </em>
                     </p>
                   </td>
@@ -184441,7 +184561,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-11.11" title="local-type: typedef-11.11">local-type: typedef-11.11</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-64.11" title="local-type: typedef-64.11">local-type: typedef-64.11</a>
                       </em>
                     </p>
                   </td>
@@ -184465,7 +184585,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-11.12" title="local-type: typedef-11.12">local-type: typedef-11.12</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-64.12" title="local-type: typedef-64.12">local-type: typedef-64.12</a>
                       </em>
                     </p>
                   </td>
@@ -184489,7 +184609,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-11.13" title="local-type: typedef-11.13">local-type: typedef-11.13</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-64.13" title="local-type: typedef-64.13">local-type: typedef-64.13</a>
                       </em>
                     </p>
                   </td>
@@ -186037,7 +186157,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-11.17" title="local-type: typedef-11.17">local-type: typedef-11.17</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-64.17" title="local-type: typedef-64.17">local-type: typedef-64.17</a>
                       </em>
                     </p>
                   </td>
@@ -186534,7 +186654,7 @@
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
                       <em>
-                        <a shape="rect" href="/home/runner/work/SIRI/SIRI/docs/generated/contab/siri.enum-dict.html#local-enum.typedef-11.1" title="local-type: typedef-11.1">local-type: typedef-11.1</a>
+                        <a shape="rect" href="/home/runner/work/SIRI/SIRI/docs/generated/contab/siri.enum-dict.html#local-enum.typedef-64.1" title="local-type: typedef-64.1">local-type: typedef-64.1</a>
                       </em>
                     </p>
                   </td>
@@ -186693,7 +186813,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-11.2" title="local-type: typedef-11.2">local-type: typedef-11.2</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-64.2" title="local-type: typedef-64.2">local-type: typedef-64.2</a>
                       </em>
                     </p>
                   </td>
@@ -187241,7 +187361,7 @@
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
                       <em>
-                        <a shape="rect" href="/home/runner/work/SIRI/SIRI/docs/generated/contab/siri.enum-dict.html#local-enum.typedef-11.3" title="local-type: typedef-11.3">local-type: typedef-11.3</a>
+                        <a shape="rect" href="/home/runner/work/SIRI/SIRI/docs/generated/contab/siri.enum-dict.html#local-enum.typedef-64.3" title="local-type: typedef-64.3">local-type: typedef-64.3</a>
                       </em>
                     </p>
                   </td>
@@ -187325,7 +187445,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-11.4" title="local-type: typedef-11.4">local-type: typedef-11.4</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-64.4" title="local-type: typedef-64.4">local-type: typedef-64.4</a>
                       </em>
                     </p>
                   </td>
@@ -187474,7 +187594,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-11.14" title="local-type: typedef-11.14">local-type: typedef-11.14</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-64.14" title="local-type: typedef-64.14">local-type: typedef-64.14</a>
                       </em>
                     </p>
                   </td>
@@ -187495,7 +187615,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-11.16" title="local-type: typedef-11.16">local-type: typedef-11.16</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-64.16" title="local-type: typedef-64.16">local-type: typedef-64.16</a>
                       </em>
                     </p>
                   </td>
@@ -188217,7 +188337,7 @@
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
                       <em>
-                        <a shape="rect" href="/home/runner/work/SIRI/SIRI/docs/generated/contab/siri.enum-dict.html#local-enum.typedef-11.1" title="local-type: typedef-11.1">local-type: typedef-11.1</a>
+                        <a shape="rect" href="/home/runner/work/SIRI/SIRI/docs/generated/contab/siri.enum-dict.html#local-enum.typedef-64.1" title="local-type: typedef-64.1">local-type: typedef-64.1</a>
                       </em>
                     </p>
                   </td>
@@ -188376,7 +188496,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-11.2" title="local-type: typedef-11.2">local-type: typedef-11.2</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-64.2" title="local-type: typedef-64.2">local-type: typedef-64.2</a>
                       </em>
                     </p>
                   </td>
@@ -188924,7 +189044,7 @@
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
                       <em>
-                        <a shape="rect" href="/home/runner/work/SIRI/SIRI/docs/generated/contab/siri.enum-dict.html#local-enum.typedef-11.3" title="local-type: typedef-11.3">local-type: typedef-11.3</a>
+                        <a shape="rect" href="/home/runner/work/SIRI/SIRI/docs/generated/contab/siri.enum-dict.html#local-enum.typedef-64.3" title="local-type: typedef-64.3">local-type: typedef-64.3</a>
                       </em>
                     </p>
                   </td>
@@ -189008,7 +189128,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-11.4" title="local-type: typedef-11.4">local-type: typedef-11.4</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-64.4" title="local-type: typedef-64.4">local-type: typedef-64.4</a>
                       </em>
                     </p>
                   </td>
@@ -189157,7 +189277,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-11.14" title="local-type: typedef-11.14">local-type: typedef-11.14</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-64.14" title="local-type: typedef-64.14">local-type: typedef-64.14</a>
                       </em>
                     </p>
                   </td>
@@ -189178,7 +189298,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-11.16" title="local-type: typedef-11.16">local-type: typedef-11.16</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-64.16" title="local-type: typedef-64.16">local-type: typedef-64.16</a>
                       </em>
                     </p>
                   </td>
@@ -189963,8 +190083,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-11.4">
-          <h3>27.53. The complex type <code>group[siri:ClassifierGroup]/SecondaryReasons#complexType (typedef-11.4)</code>
+        <div class="sect2" id="local-type.typedef-64.4">
+          <h3>27.53. The complex type <code>group[siri:ClassifierGroup]/SecondaryReasons#complexType (typedef-64.4)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -189984,7 +190104,7 @@
                       <br/>
                       <code>  /SecondaryReasons #complexType</code>
                       <br/>
-                      <code>  (typedef-11.4)</code>
+                      <code>  (typedef-64.4)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -190014,7 +190134,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-11.5" title="local-type: typedef-11.5">local-type: typedef-11.5</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-64.5" title="local-type: typedef-64.5">local-type: typedef-64.5</a>
                       </em>
                     </p>
                   </td>
@@ -190026,8 +190146,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-11.5">
-          <h3>27.54. The complex type <code>group[siri:ClassifierGroup]/SecondaryReasons/Reason#complexType (typedef-11.5)</code>
+        <div class="sect2" id="local-type.typedef-64.5">
+          <h3>27.54. The complex type <code>group[siri:ClassifierGroup]/SecondaryReasons/Reason#complexType (typedef-64.5)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -190047,7 +190167,7 @@
                       <br/>
                       <code>  /SecondaryReasons/Reason #complexType</code>
                       <br/>
-                      <code>  (typedef-11.5)</code>
+                      <code>  (typedef-64.5)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -190476,8 +190596,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-11.14">
-          <h3>27.55. The complex type <code>group[siri:DescriptionGroup]/Images#complexType (typedef-11.14)</code>
+        <div class="sect2" id="local-type.typedef-64.14">
+          <h3>27.55. The complex type <code>group[siri:DescriptionGroup]/Images#complexType (typedef-64.14)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -190497,7 +190617,7 @@
                       <br/>
                       <code>  /Images #complexType</code>
                       <br/>
-                      <code>  (typedef-11.14)</code>
+                      <code>  (typedef-64.14)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -190527,7 +190647,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-11.15" title="local-type: typedef-11.15">local-type: typedef-11.15</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-64.15" title="local-type: typedef-64.15">local-type: typedef-64.15</a>
                       </em>
                     </p>
                   </td>
@@ -190539,8 +190659,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-11.15">
-          <h3>27.56. The complex type <code>group[siri:DescriptionGroup]/Images/Image#complexType (typedef-11.15)</code>
+        <div class="sect2" id="local-type.typedef-64.15">
+          <h3>27.56. The complex type <code>group[siri:DescriptionGroup]/Images/Image#complexType (typedef-64.15)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -190560,7 +190680,7 @@
                       <br/>
                       <code>  /Images/Image #complexType</code>
                       <br/>
-                      <code>  (typedef-11.15)</code>
+                      <code>  (typedef-64.15)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -190675,8 +190795,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-11.16">
-          <h3>27.57. The complex type <code>group[siri:DescriptionGroup]/InfoLinks#complexType (typedef-11.16)</code>
+        <div class="sect2" id="local-type.typedef-64.16">
+          <h3>27.57. The complex type <code>group[siri:DescriptionGroup]/InfoLinks#complexType (typedef-64.16)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -190696,7 +190816,7 @@
                       <br/>
                       <code>  /InfoLinks #complexType</code>
                       <br/>
-                      <code>  (typedef-11.16)</code>
+                      <code>  (typedef-64.16)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -190738,8 +190858,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-11.2">
-          <h3>27.58. The complex type <code>group[siri:TemporalGroup]/Repetitions#complexType (typedef-11.2)</code>
+        <div class="sect2" id="local-type.typedef-64.2">
+          <h3>27.58. The complex type <code>group[siri:TemporalGroup]/Repetitions#complexType (typedef-64.2)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -190759,7 +190879,7 @@
                       <br/>
                       <code>  /Repetitions #complexType</code>
                       <br/>
-                      <code>  (typedef-11.2)</code>
+                      <code>  (typedef-64.2)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -190803,8 +190923,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-11.4">
-          <h3>27.59. The complex type <code>group[siri:ClassifierGroup]/SecondaryReasons#complexType (typedef-11.4)</code>
+        <div class="sect2" id="local-type.typedef-64.4">
+          <h3>27.59. The complex type <code>group[siri:ClassifierGroup]/SecondaryReasons#complexType (typedef-64.4)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -190824,7 +190944,7 @@
                       <br/>
                       <code>  /SecondaryReasons #complexType</code>
                       <br/>
-                      <code>  (typedef-11.4)</code>
+                      <code>  (typedef-64.4)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -190854,7 +190974,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-11.5" title="local-type: typedef-11.5">local-type: typedef-11.5</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-64.5" title="local-type: typedef-64.5">local-type: typedef-64.5</a>
                       </em>
                     </p>
                   </td>
@@ -190866,8 +190986,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-11.5">
-          <h3>27.60. The complex type <code>group[siri:ClassifierGroup]/SecondaryReasons/Reason#complexType (typedef-11.5)</code>
+        <div class="sect2" id="local-type.typedef-64.5">
+          <h3>27.60. The complex type <code>group[siri:ClassifierGroup]/SecondaryReasons/Reason#complexType (typedef-64.5)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -190887,7 +191007,7 @@
                       <br/>
                       <code>  /SecondaryReasons/Reason #complexType</code>
                       <br/>
-                      <code>  (typedef-11.5)</code>
+                      <code>  (typedef-64.5)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -191316,8 +191436,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-11.14">
-          <h3>27.61. The complex type <code>group[siri:DescriptionGroup]/Images#complexType (typedef-11.14)</code>
+        <div class="sect2" id="local-type.typedef-64.14">
+          <h3>27.61. The complex type <code>group[siri:DescriptionGroup]/Images#complexType (typedef-64.14)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -191337,7 +191457,7 @@
                       <br/>
                       <code>  /Images #complexType</code>
                       <br/>
-                      <code>  (typedef-11.14)</code>
+                      <code>  (typedef-64.14)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -191367,7 +191487,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-11.15" title="local-type: typedef-11.15">local-type: typedef-11.15</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-64.15" title="local-type: typedef-64.15">local-type: typedef-64.15</a>
                       </em>
                     </p>
                   </td>
@@ -191379,8 +191499,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-11.15">
-          <h3>27.62. The complex type <code>group[siri:DescriptionGroup]/Images/Image#complexType (typedef-11.15)</code>
+        <div class="sect2" id="local-type.typedef-64.15">
+          <h3>27.62. The complex type <code>group[siri:DescriptionGroup]/Images/Image#complexType (typedef-64.15)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -191400,7 +191520,7 @@
                       <br/>
                       <code>  /Images/Image #complexType</code>
                       <br/>
-                      <code>  (typedef-11.15)</code>
+                      <code>  (typedef-64.15)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -191515,8 +191635,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-11.16">
-          <h3>27.63. The complex type <code>group[siri:DescriptionGroup]/InfoLinks#complexType (typedef-11.16)</code>
+        <div class="sect2" id="local-type.typedef-64.16">
+          <h3>27.63. The complex type <code>group[siri:DescriptionGroup]/InfoLinks#complexType (typedef-64.16)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -191536,7 +191656,7 @@
                       <br/>
                       <code>  /InfoLinks #complexType</code>
                       <br/>
-                      <code>  (typedef-11.16)</code>
+                      <code>  (typedef-64.16)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -191578,8 +191698,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-11.2">
-          <h3>27.64. The complex type <code>group[siri:TemporalGroup]/Repetitions#complexType (typedef-11.2)</code>
+        <div class="sect2" id="local-type.typedef-64.2">
+          <h3>27.64. The complex type <code>group[siri:TemporalGroup]/Repetitions#complexType (typedef-64.2)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -191599,7 +191719,7 @@
                       <br/>
                       <code>  /Repetitions #complexType</code>
                       <br/>
-                      <code>  (typedef-11.2)</code>
+                      <code>  (typedef-64.2)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -191643,8 +191763,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-11.4">
-          <h3>27.65. The complex type <code>group[siri:ClassifierGroup]/SecondaryReasons#complexType (typedef-11.4)</code>
+        <div class="sect2" id="local-type.typedef-64.4">
+          <h3>27.65. The complex type <code>group[siri:ClassifierGroup]/SecondaryReasons#complexType (typedef-64.4)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -191664,7 +191784,7 @@
                       <br/>
                       <code>  /SecondaryReasons #complexType</code>
                       <br/>
-                      <code>  (typedef-11.4)</code>
+                      <code>  (typedef-64.4)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -191694,7 +191814,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-11.5" title="local-type: typedef-11.5">local-type: typedef-11.5</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-64.5" title="local-type: typedef-64.5">local-type: typedef-64.5</a>
                       </em>
                     </p>
                   </td>
@@ -191706,8 +191826,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-11.5">
-          <h3>27.66. The complex type <code>group[siri:ClassifierGroup]/SecondaryReasons/Reason#complexType (typedef-11.5)</code>
+        <div class="sect2" id="local-type.typedef-64.5">
+          <h3>27.66. The complex type <code>group[siri:ClassifierGroup]/SecondaryReasons/Reason#complexType (typedef-64.5)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -191727,7 +191847,7 @@
                       <br/>
                       <code>  /SecondaryReasons/Reason #complexType</code>
                       <br/>
-                      <code>  (typedef-11.5)</code>
+                      <code>  (typedef-64.5)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -192156,8 +192276,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-11.14">
-          <h3>27.67. The complex type <code>group[siri:DescriptionGroup]/Images#complexType (typedef-11.14)</code>
+        <div class="sect2" id="local-type.typedef-64.14">
+          <h3>27.67. The complex type <code>group[siri:DescriptionGroup]/Images#complexType (typedef-64.14)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -192177,7 +192297,7 @@
                       <br/>
                       <code>  /Images #complexType</code>
                       <br/>
-                      <code>  (typedef-11.14)</code>
+                      <code>  (typedef-64.14)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -192207,7 +192327,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-11.15" title="local-type: typedef-11.15">local-type: typedef-11.15</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-64.15" title="local-type: typedef-64.15">local-type: typedef-64.15</a>
                       </em>
                     </p>
                   </td>
@@ -192219,8 +192339,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-11.15">
-          <h3>27.68. The complex type <code>group[siri:DescriptionGroup]/Images/Image#complexType (typedef-11.15)</code>
+        <div class="sect2" id="local-type.typedef-64.15">
+          <h3>27.68. The complex type <code>group[siri:DescriptionGroup]/Images/Image#complexType (typedef-64.15)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -192240,7 +192360,7 @@
                       <br/>
                       <code>  /Images/Image #complexType</code>
                       <br/>
-                      <code>  (typedef-11.15)</code>
+                      <code>  (typedef-64.15)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -192355,8 +192475,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-11.16">
-          <h3>27.69. The complex type <code>group[siri:DescriptionGroup]/InfoLinks#complexType (typedef-11.16)</code>
+        <div class="sect2" id="local-type.typedef-64.16">
+          <h3>27.69. The complex type <code>group[siri:DescriptionGroup]/InfoLinks#complexType (typedef-64.16)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -192376,7 +192496,7 @@
                       <br/>
                       <code>  /InfoLinks #complexType</code>
                       <br/>
-                      <code>  (typedef-11.16)</code>
+                      <code>  (typedef-64.16)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -192418,8 +192538,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-11.2">
-          <h3>27.70. The complex type <code>group[siri:TemporalGroup]/Repetitions#complexType (typedef-11.2)</code>
+        <div class="sect2" id="local-type.typedef-64.2">
+          <h3>27.70. The complex type <code>group[siri:TemporalGroup]/Repetitions#complexType (typedef-64.2)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -192439,7 +192559,7 @@
                       <br/>
                       <code>  /Repetitions #complexType</code>
                       <br/>
-                      <code>  (typedef-11.2)</code>
+                      <code>  (typedef-64.2)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -192483,8 +192603,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-11.6">
-          <h3>27.71. The complex type <code>complexType[siri:AffectsScopeStructure]/Operators#complexType (typedef-11.6)</code>
+        <div class="sect2" id="local-type.typedef-64.6">
+          <h3>27.71. The complex type <code>complexType[siri:AffectsScopeStructure]/Operators#complexType (typedef-64.6)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -192504,7 +192624,7 @@
                       <br/>
                       <code>  /Operators #complexType</code>
                       <br/>
-                      <code>  (typedef-11.6)</code>
+                      <code>  (typedef-64.6)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -192590,8 +192710,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-11.7">
-          <h3>27.72. The complex type <code>complexType[siri:AffectsScopeStructure]/Networks#complexType (typedef-11.7)</code>
+        <div class="sect2" id="local-type.typedef-64.7">
+          <h3>27.72. The complex type <code>complexType[siri:AffectsScopeStructure]/Networks#complexType (typedef-64.7)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -192611,7 +192731,7 @@
                       <br/>
                       <code>  /Networks #complexType</code>
                       <br/>
-                      <code>  (typedef-11.7)</code>
+                      <code>  (typedef-64.7)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -192641,7 +192761,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-11.8" title="local-type: typedef-11.8">local-type: typedef-11.8</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-64.8" title="local-type: typedef-64.8">local-type: typedef-64.8</a>
                       </em>
                     </p>
                   </td>
@@ -192653,8 +192773,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-11.8">
-          <h3>27.73. The complex type <code>complexType[siri:AffectsScopeStructure]/Networks/AffectedNetwork#complexType (typedef-11.8)</code>
+        <div class="sect2" id="local-type.typedef-64.8">
+          <h3>27.73. The complex type <code>complexType[siri:AffectsScopeStructure]/Networks/AffectedNetwork#complexType (typedef-64.8)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -192674,7 +192794,7 @@
                       <br/>
                       <code>  /Networks/AffectedNetwork #complexType</code>
                       <br/>
-                      <code>  (typedef-11.8)</code>
+                      <code>  (typedef-64.8)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -193269,8 +193389,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-11.9">
-          <h3>27.74. The complex type <code>complexType[siri:AffectsScopeStructure]/StopPoints#complexType (typedef-11.9)</code>
+        <div class="sect2" id="local-type.typedef-64.9">
+          <h3>27.74. The complex type <code>complexType[siri:AffectsScopeStructure]/StopPoints#complexType (typedef-64.9)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -193290,7 +193410,7 @@
                       <br/>
                       <code>  /StopPoints #complexType</code>
                       <br/>
-                      <code>  (typedef-11.9)</code>
+                      <code>  (typedef-64.9)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -193332,8 +193452,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-11.10">
-          <h3>27.75. The complex type <code>complexType[siri:AffectsScopeStructure]/StopPlaces#complexType (typedef-11.10)</code>
+        <div class="sect2" id="local-type.typedef-64.10">
+          <h3>27.75. The complex type <code>complexType[siri:AffectsScopeStructure]/StopPlaces#complexType (typedef-64.10)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -193353,7 +193473,7 @@
                       <br/>
                       <code>  /StopPlaces #complexType</code>
                       <br/>
-                      <code>  (typedef-11.10)</code>
+                      <code>  (typedef-64.10)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -193395,8 +193515,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-11.11">
-          <h3>27.76. The complex type <code>complexType[siri:AffectsScopeStructure]/Places#complexType (typedef-11.11)</code>
+        <div class="sect2" id="local-type.typedef-64.11">
+          <h3>27.76. The complex type <code>complexType[siri:AffectsScopeStructure]/Places#complexType (typedef-64.11)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -193416,7 +193536,7 @@
                       <br/>
                       <code>  /Places #complexType</code>
                       <br/>
-                      <code>  (typedef-11.11)</code>
+                      <code>  (typedef-64.11)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -193458,8 +193578,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-11.12">
-          <h3>27.77. The complex type <code>complexType[siri:AffectsScopeStructure]/VehicleJourneys#complexType (typedef-11.12)</code>
+        <div class="sect2" id="local-type.typedef-64.12">
+          <h3>27.77. The complex type <code>complexType[siri:AffectsScopeStructure]/VehicleJourneys#complexType (typedef-64.12)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -193479,7 +193599,7 @@
                       <br/>
                       <code>  /VehicleJourneys #complexType</code>
                       <br/>
-                      <code>  (typedef-11.12)</code>
+                      <code>  (typedef-64.12)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -193521,8 +193641,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-11.13">
-          <h3>27.78. The complex type <code>complexType[siri:AffectsScopeStructure]/Vehicles#complexType (typedef-11.13)</code>
+        <div class="sect2" id="local-type.typedef-64.13">
+          <h3>27.78. The complex type <code>complexType[siri:AffectsScopeStructure]/Vehicles#complexType (typedef-64.13)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -193542,7 +193662,7 @@
                       <br/>
                       <code>  /Vehicles #complexType</code>
                       <br/>
-                      <code>  (typedef-11.13)</code>
+                      <code>  (typedef-64.13)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -193584,8 +193704,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-11.17">
-          <h3>27.79. The complex type <code>complexType[siri:PtConsequenceStructure]/Suitabilities#complexType (typedef-11.17)</code>
+        <div class="sect2" id="local-type.typedef-64.17">
+          <h3>27.79. The complex type <code>complexType[siri:PtConsequenceStructure]/Suitabilities#complexType (typedef-64.17)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -193605,7 +193725,7 @@
                       <br/>
                       <code>  /Suitabilities #complexType</code>
                       <br/>
-                      <code>  (typedef-11.17)</code>
+                      <code>  (typedef-64.17)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -193647,8 +193767,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-11.2">
-          <h3>27.80. The complex type <code>group[siri:TemporalGroup]/Repetitions#complexType (typedef-11.2)</code>
+        <div class="sect2" id="local-type.typedef-64.2">
+          <h3>27.80. The complex type <code>group[siri:TemporalGroup]/Repetitions#complexType (typedef-64.2)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -193668,7 +193788,7 @@
                       <br/>
                       <code>  /Repetitions #complexType</code>
                       <br/>
-                      <code>  (typedef-11.2)</code>
+                      <code>  (typedef-64.2)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -193712,8 +193832,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-11.4">
-          <h3>27.81. The complex type <code>group[siri:ClassifierGroup]/SecondaryReasons#complexType (typedef-11.4)</code>
+        <div class="sect2" id="local-type.typedef-64.4">
+          <h3>27.81. The complex type <code>group[siri:ClassifierGroup]/SecondaryReasons#complexType (typedef-64.4)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -193733,7 +193853,7 @@
                       <br/>
                       <code>  /SecondaryReasons #complexType</code>
                       <br/>
-                      <code>  (typedef-11.4)</code>
+                      <code>  (typedef-64.4)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -193763,7 +193883,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-11.5" title="local-type: typedef-11.5">local-type: typedef-11.5</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-64.5" title="local-type: typedef-64.5">local-type: typedef-64.5</a>
                       </em>
                     </p>
                   </td>
@@ -193775,8 +193895,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-11.5">
-          <h3>27.82. The complex type <code>group[siri:ClassifierGroup]/SecondaryReasons/Reason#complexType (typedef-11.5)</code>
+        <div class="sect2" id="local-type.typedef-64.5">
+          <h3>27.82. The complex type <code>group[siri:ClassifierGroup]/SecondaryReasons/Reason#complexType (typedef-64.5)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -193796,7 +193916,7 @@
                       <br/>
                       <code>  /SecondaryReasons/Reason #complexType</code>
                       <br/>
-                      <code>  (typedef-11.5)</code>
+                      <code>  (typedef-64.5)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -194225,8 +194345,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-11.14">
-          <h3>27.83. The complex type <code>group[siri:DescriptionGroup]/Images#complexType (typedef-11.14)</code>
+        <div class="sect2" id="local-type.typedef-64.14">
+          <h3>27.83. The complex type <code>group[siri:DescriptionGroup]/Images#complexType (typedef-64.14)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -194246,7 +194366,7 @@
                       <br/>
                       <code>  /Images #complexType</code>
                       <br/>
-                      <code>  (typedef-11.14)</code>
+                      <code>  (typedef-64.14)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -194276,7 +194396,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-11.15" title="local-type: typedef-11.15">local-type: typedef-11.15</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-64.15" title="local-type: typedef-64.15">local-type: typedef-64.15</a>
                       </em>
                     </p>
                   </td>
@@ -194288,8 +194408,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-11.15">
-          <h3>27.84. The complex type <code>group[siri:DescriptionGroup]/Images/Image#complexType (typedef-11.15)</code>
+        <div class="sect2" id="local-type.typedef-64.15">
+          <h3>27.84. The complex type <code>group[siri:DescriptionGroup]/Images/Image#complexType (typedef-64.15)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -194309,7 +194429,7 @@
                       <br/>
                       <code>  /Images/Image #complexType</code>
                       <br/>
-                      <code>  (typedef-11.15)</code>
+                      <code>  (typedef-64.15)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -194424,8 +194544,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-11.16">
-          <h3>27.85. The complex type <code>group[siri:DescriptionGroup]/InfoLinks#complexType (typedef-11.16)</code>
+        <div class="sect2" id="local-type.typedef-64.16">
+          <h3>27.85. The complex type <code>group[siri:DescriptionGroup]/InfoLinks#complexType (typedef-64.16)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -194445,7 +194565,7 @@
                       <br/>
                       <code>  /InfoLinks #complexType</code>
                       <br/>
-                      <code>  (typedef-11.16)</code>
+                      <code>  (typedef-64.16)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -194487,8 +194607,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-11.2">
-          <h3>27.86. The complex type <code>group[siri:TemporalGroup]/Repetitions#complexType (typedef-11.2)</code>
+        <div class="sect2" id="local-type.typedef-64.2">
+          <h3>27.86. The complex type <code>group[siri:TemporalGroup]/Repetitions#complexType (typedef-64.2)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -194508,7 +194628,7 @@
                       <br/>
                       <code>  /Repetitions #complexType</code>
                       <br/>
-                      <code>  (typedef-11.2)</code>
+                      <code>  (typedef-64.2)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -194552,8 +194672,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-11.4">
-          <h3>27.87. The complex type <code>group[siri:ClassifierGroup]/SecondaryReasons#complexType (typedef-11.4)</code>
+        <div class="sect2" id="local-type.typedef-64.4">
+          <h3>27.87. The complex type <code>group[siri:ClassifierGroup]/SecondaryReasons#complexType (typedef-64.4)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -194573,7 +194693,7 @@
                       <br/>
                       <code>  /SecondaryReasons #complexType</code>
                       <br/>
-                      <code>  (typedef-11.4)</code>
+                      <code>  (typedef-64.4)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -194603,7 +194723,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-11.5" title="local-type: typedef-11.5">local-type: typedef-11.5</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-64.5" title="local-type: typedef-64.5">local-type: typedef-64.5</a>
                       </em>
                     </p>
                   </td>
@@ -194615,8 +194735,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-11.5">
-          <h3>27.88. The complex type <code>group[siri:ClassifierGroup]/SecondaryReasons/Reason#complexType (typedef-11.5)</code>
+        <div class="sect2" id="local-type.typedef-64.5">
+          <h3>27.88. The complex type <code>group[siri:ClassifierGroup]/SecondaryReasons/Reason#complexType (typedef-64.5)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -194636,7 +194756,7 @@
                       <br/>
                       <code>  /SecondaryReasons/Reason #complexType</code>
                       <br/>
-                      <code>  (typedef-11.5)</code>
+                      <code>  (typedef-64.5)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -195065,8 +195185,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-11.14">
-          <h3>27.89. The complex type <code>group[siri:DescriptionGroup]/Images#complexType (typedef-11.14)</code>
+        <div class="sect2" id="local-type.typedef-64.14">
+          <h3>27.89. The complex type <code>group[siri:DescriptionGroup]/Images#complexType (typedef-64.14)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -195086,7 +195206,7 @@
                       <br/>
                       <code>  /Images #complexType</code>
                       <br/>
-                      <code>  (typedef-11.14)</code>
+                      <code>  (typedef-64.14)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -195116,7 +195236,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-11.15" title="local-type: typedef-11.15">local-type: typedef-11.15</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-64.15" title="local-type: typedef-64.15">local-type: typedef-64.15</a>
                       </em>
                     </p>
                   </td>
@@ -195128,8 +195248,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-11.15">
-          <h3>27.90. The complex type <code>group[siri:DescriptionGroup]/Images/Image#complexType (typedef-11.15)</code>
+        <div class="sect2" id="local-type.typedef-64.15">
+          <h3>27.90. The complex type <code>group[siri:DescriptionGroup]/Images/Image#complexType (typedef-64.15)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -195149,7 +195269,7 @@
                       <br/>
                       <code>  /Images/Image #complexType</code>
                       <br/>
-                      <code>  (typedef-11.15)</code>
+                      <code>  (typedef-64.15)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -195264,8 +195384,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-11.16">
-          <h3>27.91. The complex type <code>group[siri:DescriptionGroup]/InfoLinks#complexType (typedef-11.16)</code>
+        <div class="sect2" id="local-type.typedef-64.16">
+          <h3>27.91. The complex type <code>group[siri:DescriptionGroup]/InfoLinks#complexType (typedef-64.16)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -195285,7 +195405,7 @@
                       <br/>
                       <code>  /InfoLinks #complexType</code>
                       <br/>
-                      <code>  (typedef-11.16)</code>
+                      <code>  (typedef-64.16)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -196124,7 +196244,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-15.3" title="local-type: typedef-15.3">local-type: typedef-15.3</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-71.3" title="local-type: typedef-71.3">local-type: typedef-71.3</a>
                       </em>
                     </p>
                   </td>
@@ -196364,7 +196484,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-15.2" title="local-type: typedef-15.2">local-type: typedef-15.2</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-71.2" title="local-type: typedef-71.2">local-type: typedef-71.2</a>
                       </em>
                     </p>
                   </td>
@@ -196530,7 +196650,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-15.3" title="local-type: typedef-15.3">local-type: typedef-15.3</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-71.3" title="local-type: typedef-71.3">local-type: typedef-71.3</a>
                       </em>
                     </p>
                   </td>
@@ -197228,7 +197348,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-15.1" title="local-type: typedef-15.1">local-type: typedef-15.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-71.1" title="local-type: typedef-71.1">local-type: typedef-71.1</a>
                       </em>
                     </p>
                   </td>
@@ -197463,7 +197583,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-15.1" title="local-type: typedef-15.1">local-type: typedef-15.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-71.1" title="local-type: typedef-71.1">local-type: typedef-71.1</a>
                       </em>
                     </p>
                   </td>
@@ -197719,7 +197839,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-15.1" title="local-type: typedef-15.1">local-type: typedef-15.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-71.1" title="local-type: typedef-71.1">local-type: typedef-71.1</a>
                       </em>
                     </p>
                   </td>
@@ -197977,7 +198097,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-15.1" title="local-type: typedef-15.1">local-type: typedef-15.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-71.1" title="local-type: typedef-71.1">local-type: typedef-71.1</a>
                       </em>
                     </p>
                   </td>
@@ -198713,7 +198833,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-15.4" title="local-type: typedef-15.4">local-type: typedef-15.4</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-71.4" title="local-type: typedef-71.4">local-type: typedef-71.4</a>
                       </em>
                     </p>
                   </td>
@@ -198924,7 +199044,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-15.1" title="local-type: typedef-15.1">local-type: typedef-15.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-71.1" title="local-type: typedef-71.1">local-type: typedef-71.1</a>
                       </em>
                     </p>
                   </td>
@@ -200067,7 +200187,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-15.1" title="local-type: typedef-15.1">local-type: typedef-15.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-71.1" title="local-type: typedef-71.1">local-type: typedef-71.1</a>
                       </em>
                     </p>
                   </td>
@@ -200617,7 +200737,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-15.3" title="local-type: typedef-15.3">local-type: typedef-15.3</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-71.3" title="local-type: typedef-71.3">local-type: typedef-71.3</a>
                       </em>
                     </p>
                   </td>
@@ -200961,8 +201081,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-15.3">
-          <h3>28.41. The complex type <code>element[siri:ManualAction]#complexType (typedef-15.3)</code>
+        <div class="sect2" id="local-type.typedef-71.3">
+          <h3>28.41. The complex type <code>element[siri:ManualAction]#complexType (typedef-71.3)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -200982,7 +201102,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-15.3)</code>
+                      <code>  (typedef-71.3)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -201123,8 +201243,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-15.3">
-          <h3>28.42. The complex type <code>element[siri:ManualAction]#complexType (typedef-15.3)</code>
+        <div class="sect2" id="local-type.typedef-71.3">
+          <h3>28.42. The complex type <code>element[siri:ManualAction]#complexType (typedef-71.3)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -201144,7 +201264,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-15.3)</code>
+                      <code>  (typedef-71.3)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -201285,8 +201405,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-15.2">
-          <h3>28.43. The complex type <code>complexType[siri:ActionDataStructure]/PublishAtScope#complexType (typedef-15.2)</code>
+        <div class="sect2" id="local-type.typedef-71.2">
+          <h3>28.43. The complex type <code>complexType[siri:ActionDataStructure]/PublishAtScope#complexType (typedef-71.2)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -201306,7 +201426,7 @@
                       <br/>
                       <code>  /PublishAtScope #complexType</code>
                       <br/>
-                      <code>  (typedef-15.2)</code>
+                      <code>  (typedef-71.2)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -201373,8 +201493,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-15.3">
-          <h3>28.44. The complex type <code>element[siri:ManualAction]#complexType (typedef-15.3)</code>
+        <div class="sect2" id="local-type.typedef-71.3">
+          <h3>28.44. The complex type <code>element[siri:ManualAction]#complexType (typedef-71.3)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -201394,7 +201514,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-15.3)</code>
+                      <code>  (typedef-71.3)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -201535,8 +201655,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-15.1">
-          <h3>28.45. The complex type <code>complexType[siri:PushedActionStructure]/BeforeNotices#complexType (typedef-15.1)</code>
+        <div class="sect2" id="local-type.typedef-71.1">
+          <h3>28.45. The complex type <code>complexType[siri:PushedActionStructure]/BeforeNotices#complexType (typedef-71.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -201556,7 +201676,7 @@
                       <br/>
                       <code>  /BeforeNotices #complexType</code>
                       <br/>
-                      <code>  (typedef-15.1)</code>
+                      <code>  (typedef-71.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -201595,8 +201715,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-15.1">
-          <h3>28.46. The complex type <code>complexType[siri:PushedActionStructure]/BeforeNotices#complexType (typedef-15.1)</code>
+        <div class="sect2" id="local-type.typedef-71.1">
+          <h3>28.46. The complex type <code>complexType[siri:PushedActionStructure]/BeforeNotices#complexType (typedef-71.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -201616,7 +201736,7 @@
                       <br/>
                       <code>  /BeforeNotices #complexType</code>
                       <br/>
-                      <code>  (typedef-15.1)</code>
+                      <code>  (typedef-71.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -201655,8 +201775,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-15.1">
-          <h3>28.47. The complex type <code>complexType[siri:PushedActionStructure]/BeforeNotices#complexType (typedef-15.1)</code>
+        <div class="sect2" id="local-type.typedef-71.1">
+          <h3>28.47. The complex type <code>complexType[siri:PushedActionStructure]/BeforeNotices#complexType (typedef-71.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -201676,7 +201796,7 @@
                       <br/>
                       <code>  /BeforeNotices #complexType</code>
                       <br/>
-                      <code>  (typedef-15.1)</code>
+                      <code>  (typedef-71.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -201715,8 +201835,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-15.1">
-          <h3>28.48. The complex type <code>complexType[siri:PushedActionStructure]/BeforeNotices#complexType (typedef-15.1)</code>
+        <div class="sect2" id="local-type.typedef-71.1">
+          <h3>28.48. The complex type <code>complexType[siri:PushedActionStructure]/BeforeNotices#complexType (typedef-71.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -201736,7 +201856,7 @@
                       <br/>
                       <code>  /BeforeNotices #complexType</code>
                       <br/>
-                      <code>  (typedef-15.1)</code>
+                      <code>  (typedef-71.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -201775,8 +201895,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-15.4">
-          <h3>28.49. The complex type <code>complexType[siri:PublishingActionStructure]/PublishAtScope#complexType (typedef-15.4)</code>
+        <div class="sect2" id="local-type.typedef-71.4">
+          <h3>28.49. The complex type <code>complexType[siri:PublishingActionStructure]/PublishAtScope#complexType (typedef-71.4)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -201796,7 +201916,7 @@
                       <br/>
                       <code>  /PublishAtScope #complexType</code>
                       <br/>
-                      <code>  (typedef-15.4)</code>
+                      <code>  (typedef-71.4)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -201863,8 +201983,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-15.1">
-          <h3>28.50. The complex type <code>complexType[siri:PushedActionStructure]/BeforeNotices#complexType (typedef-15.1)</code>
+        <div class="sect2" id="local-type.typedef-71.1">
+          <h3>28.50. The complex type <code>complexType[siri:PushedActionStructure]/BeforeNotices#complexType (typedef-71.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -201884,7 +202004,7 @@
                       <br/>
                       <code>  /BeforeNotices #complexType</code>
                       <br/>
-                      <code>  (typedef-15.1)</code>
+                      <code>  (typedef-71.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -201923,8 +202043,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-15.1">
-          <h3>28.51. The complex type <code>complexType[siri:PushedActionStructure]/BeforeNotices#complexType (typedef-15.1)</code>
+        <div class="sect2" id="local-type.typedef-71.1">
+          <h3>28.51. The complex type <code>complexType[siri:PushedActionStructure]/BeforeNotices#complexType (typedef-71.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -201944,7 +202064,7 @@
                       <br/>
                       <code>  /BeforeNotices #complexType</code>
                       <br/>
-                      <code>  (typedef-15.1)</code>
+                      <code>  (typedef-71.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -201983,8 +202103,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-15.3">
-          <h3>28.52. The complex type <code>element[siri:ManualAction]#complexType (typedef-15.3)</code>
+        <div class="sect2" id="local-type.typedef-71.3">
+          <h3>28.52. The complex type <code>element[siri:ManualAction]#complexType (typedef-71.3)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -202004,7 +202124,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-15.3)</code>
+                      <code>  (typedef-71.3)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -203896,7 +204016,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-22.1" title="local-type: typedef-22.1">local-type: typedef-22.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-68.1" title="local-type: typedef-68.1">local-type: typedef-68.1</a>
                       </em>
                     </p>
                   </td>
@@ -203920,7 +204040,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-22.2" title="local-type: typedef-22.2">local-type: typedef-22.2</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-68.2" title="local-type: typedef-68.2">local-type: typedef-68.2</a>
                       </em>
                     </p>
                   </td>
@@ -204526,7 +204646,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-22.16" title="local-type: typedef-22.16">local-type: typedef-22.16</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-68.16" title="local-type: typedef-68.16">local-type: typedef-68.16</a>
                       </em>
                     </p>
                   </td>
@@ -205484,7 +205604,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-22.4" title="local-type: typedef-22.4">local-type: typedef-22.4</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-68.4" title="local-type: typedef-68.4">local-type: typedef-68.4</a>
                       </em>
                     </p>
                   </td>
@@ -205508,7 +205628,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-22.5" title="local-type: typedef-22.5">local-type: typedef-22.5</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-68.5" title="local-type: typedef-68.5">local-type: typedef-68.5</a>
                       </em>
                     </p>
                   </td>
@@ -205532,7 +205652,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-22.6" title="local-type: typedef-22.6">local-type: typedef-22.6</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-68.6" title="local-type: typedef-68.6">local-type: typedef-68.6</a>
                       </em>
                     </p>
                   </td>
@@ -205556,7 +205676,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-22.7" title="local-type: typedef-22.7">local-type: typedef-22.7</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-68.7" title="local-type: typedef-68.7">local-type: typedef-68.7</a>
                       </em>
                     </p>
                   </td>
@@ -205782,7 +205902,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-22.3" title="local-type: typedef-22.3">local-type: typedef-22.3</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-68.3" title="local-type: typedef-68.3">local-type: typedef-68.3</a>
                       </em>
                     </p>
                   </td>
@@ -207058,7 +207178,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-22.9" title="local-type: typedef-22.9">local-type: typedef-22.9</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-68.9" title="local-type: typedef-68.9">local-type: typedef-68.9</a>
                       </em>
                     </p>
                   </td>
@@ -207082,7 +207202,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-22.10" title="local-type: typedef-22.10">local-type: typedef-22.10</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-68.10" title="local-type: typedef-68.10">local-type: typedef-68.10</a>
                       </em>
                     </p>
                   </td>
@@ -207106,7 +207226,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-22.11" title="local-type: typedef-22.11">local-type: typedef-22.11</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-68.11" title="local-type: typedef-68.11">local-type: typedef-68.11</a>
                       </em>
                     </p>
                   </td>
@@ -207229,7 +207349,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-22.8" title="local-type: typedef-22.8">local-type: typedef-22.8</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-68.8" title="local-type: typedef-68.8">local-type: typedef-68.8</a>
                       </em>
                     </p>
                   </td>
@@ -207585,7 +207705,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-22.21" title="local-type: typedef-22.21">local-type: typedef-22.21</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-68.21" title="local-type: typedef-68.21">local-type: typedef-68.21</a>
                       </em>
                     </p>
                   </td>
@@ -207852,7 +207972,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-22.18" title="local-type: typedef-22.18">local-type: typedef-22.18</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-68.18" title="local-type: typedef-68.18">local-type: typedef-68.18</a>
                       </em>
                     </p>
                   </td>
@@ -207876,7 +207996,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-22.19" title="local-type: typedef-22.19">local-type: typedef-22.19</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-68.19" title="local-type: typedef-68.19">local-type: typedef-68.19</a>
                       </em>
                     </p>
                   </td>
@@ -207900,7 +208020,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-22.20" title="local-type: typedef-22.20">local-type: typedef-22.20</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-68.20" title="local-type: typedef-68.20">local-type: typedef-68.20</a>
                       </em>
                     </p>
                   </td>
@@ -207929,7 +208049,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-22.17" title="local-type: typedef-22.17">local-type: typedef-22.17</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-68.17" title="local-type: typedef-68.17">local-type: typedef-68.17</a>
                       </em>
                     </p>
                   </td>
@@ -208146,7 +208266,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-22.18" title="local-type: typedef-22.18">local-type: typedef-22.18</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-68.18" title="local-type: typedef-68.18">local-type: typedef-68.18</a>
                       </em>
                     </p>
                   </td>
@@ -208170,7 +208290,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-22.19" title="local-type: typedef-22.19">local-type: typedef-22.19</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-68.19" title="local-type: typedef-68.19">local-type: typedef-68.19</a>
                       </em>
                     </p>
                   </td>
@@ -208194,7 +208314,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-22.20" title="local-type: typedef-22.20">local-type: typedef-22.20</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-68.20" title="local-type: typedef-68.20">local-type: typedef-68.20</a>
                       </em>
                     </p>
                   </td>
@@ -208546,7 +208666,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-22.1" title="local-type: typedef-22.1">local-type: typedef-22.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-68.1" title="local-type: typedef-68.1">local-type: typedef-68.1</a>
                       </em>
                     </p>
                   </td>
@@ -208575,7 +208695,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-22.2" title="local-type: typedef-22.2">local-type: typedef-22.2</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-68.2" title="local-type: typedef-68.2">local-type: typedef-68.2</a>
                       </em>
                     </p>
                   </td>
@@ -208945,7 +209065,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-22.1" title="local-type: typedef-22.1">local-type: typedef-22.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-68.1" title="local-type: typedef-68.1">local-type: typedef-68.1</a>
                       </em>
                     </p>
                   </td>
@@ -209289,7 +209409,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-22.12" title="local-type: typedef-22.12">local-type: typedef-22.12</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-68.12" title="local-type: typedef-68.12">local-type: typedef-68.12</a>
                       </em>
                     </p>
                   </td>
@@ -209313,7 +209433,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-22.13" title="local-type: typedef-22.13">local-type: typedef-22.13</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-68.13" title="local-type: typedef-68.13">local-type: typedef-68.13</a>
                       </em>
                     </p>
                   </td>
@@ -209552,7 +209672,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-22.14" title="local-type: typedef-22.14">local-type: typedef-22.14</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-68.14" title="local-type: typedef-68.14">local-type: typedef-68.14</a>
                       </em>
                     </p>
                   </td>
@@ -209576,7 +209696,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-22.15" title="local-type: typedef-22.15">local-type: typedef-22.15</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-68.15" title="local-type: typedef-68.15">local-type: typedef-68.15</a>
                       </em>
                     </p>
                   </td>
@@ -210796,8 +210916,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-22.1">
-          <h3>29.44. The complex type <code>complexType[siri:AffectedStopPointWithoutLineStructure]/ConnectionLinks#complexType (typedef-22.1)</code>
+        <div class="sect2" id="local-type.typedef-68.1">
+          <h3>29.44. The complex type <code>complexType[siri:AffectedStopPointWithoutLineStructure]/ConnectionLinks#complexType (typedef-68.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -210817,7 +210937,7 @@
                       <br/>
                       <code>  /ConnectionLinks #complexType</code>
                       <br/>
-                      <code>  (typedef-22.1)</code>
+                      <code>  (typedef-68.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -210859,8 +210979,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-22.2">
-          <h3>29.45. The complex type <code>complexType[siri:AffectedStopPointStructure]/Lines#complexType (typedef-22.2)</code>
+        <div class="sect2" id="local-type.typedef-68.2">
+          <h3>29.45. The complex type <code>complexType[siri:AffectedStopPointStructure]/Lines#complexType (typedef-68.2)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -210880,7 +211000,7 @@
                       <br/>
                       <code>  /Lines #complexType</code>
                       <br/>
-                      <code>  (typedef-22.2)</code>
+                      <code>  (typedef-68.2)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -210922,8 +211042,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-22.16">
-          <h3>29.46. The complex type <code>complexType[siri:AffectedCallStructure]/AffectedInterchanges#complexType (typedef-22.16)</code>
+        <div class="sect2" id="local-type.typedef-68.16">
+          <h3>29.46. The complex type <code>complexType[siri:AffectedCallStructure]/AffectedInterchanges#complexType (typedef-68.16)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -210943,7 +211063,7 @@
                       <br/>
                       <code>  /AffectedInterchanges #complexType</code>
                       <br/>
-                      <code>  (typedef-22.16)</code>
+                      <code>  (typedef-68.16)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -210981,8 +211101,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-22.4">
-          <h3>29.47. The complex type <code>complexType[siri:AffectedLineStructure]/Routes#complexType (typedef-22.4)</code>
+        <div class="sect2" id="local-type.typedef-68.4">
+          <h3>29.47. The complex type <code>complexType[siri:AffectedLineStructure]/Routes#complexType (typedef-68.4)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -211002,7 +211122,7 @@
                       <br/>
                       <code>  /Routes #complexType</code>
                       <br/>
-                      <code>  (typedef-22.4)</code>
+                      <code>  (typedef-68.4)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -211044,8 +211164,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-22.5">
-          <h3>29.48. The complex type <code>complexType[siri:AffectedLineStructure]/Sections#complexType (typedef-22.5)</code>
+        <div class="sect2" id="local-type.typedef-68.5">
+          <h3>29.48. The complex type <code>complexType[siri:AffectedLineStructure]/Sections#complexType (typedef-68.5)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -211065,7 +211185,7 @@
                       <br/>
                       <code>  /Sections #complexType</code>
                       <br/>
-                      <code>  (typedef-22.5)</code>
+                      <code>  (typedef-68.5)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -211107,8 +211227,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-22.6">
-          <h3>29.49. The complex type <code>complexType[siri:AffectedLineStructure]/StopPoints#complexType (typedef-22.6)</code>
+        <div class="sect2" id="local-type.typedef-68.6">
+          <h3>29.49. The complex type <code>complexType[siri:AffectedLineStructure]/StopPoints#complexType (typedef-68.6)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -211128,7 +211248,7 @@
                       <br/>
                       <code>  /StopPoints #complexType</code>
                       <br/>
-                      <code>  (typedef-22.6)</code>
+                      <code>  (typedef-68.6)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -211170,8 +211290,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-22.7">
-          <h3>29.50. The complex type <code>complexType[siri:AffectedLineStructure]/StopPlaces#complexType (typedef-22.7)</code>
+        <div class="sect2" id="local-type.typedef-68.7">
+          <h3>29.50. The complex type <code>complexType[siri:AffectedLineStructure]/StopPlaces#complexType (typedef-68.7)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -211191,7 +211311,7 @@
                       <br/>
                       <code>  /StopPlaces #complexType</code>
                       <br/>
-                      <code>  (typedef-22.7)</code>
+                      <code>  (typedef-68.7)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -211233,8 +211353,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-22.3">
-          <h3>29.51. The complex type <code>complexType[siri:AffectedModesStructure]/Mode#complexType (typedef-22.3)</code>
+        <div class="sect2" id="local-type.typedef-68.3">
+          <h3>29.51. The complex type <code>complexType[siri:AffectedModesStructure]/Mode#complexType (typedef-68.3)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -211254,7 +211374,7 @@
                       <br/>
                       <code>  /Mode #complexType</code>
                       <br/>
-                      <code>  (typedef-22.3)</code>
+                      <code>  (typedef-68.3)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -211583,8 +211703,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-22.9">
-          <h3>29.52. The complex type <code>complexType[siri:AffectedRouteStructure]/Sections#complexType (typedef-22.9)</code>
+        <div class="sect2" id="local-type.typedef-68.9">
+          <h3>29.52. The complex type <code>complexType[siri:AffectedRouteStructure]/Sections#complexType (typedef-68.9)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -211604,7 +211724,7 @@
                       <br/>
                       <code>  /Sections #complexType</code>
                       <br/>
-                      <code>  (typedef-22.9)</code>
+                      <code>  (typedef-68.9)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -211646,8 +211766,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-22.10">
-          <h3>29.53. The complex type <code>complexType[siri:AffectedRouteStructure]/StopPoints#complexType (typedef-22.10)</code>
+        <div class="sect2" id="local-type.typedef-68.10">
+          <h3>29.53. The complex type <code>complexType[siri:AffectedRouteStructure]/StopPoints#complexType (typedef-68.10)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -211667,7 +211787,7 @@
                       <br/>
                       <code>  /StopPoints #complexType</code>
                       <br/>
-                      <code>  (typedef-22.10)</code>
+                      <code>  (typedef-68.10)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -211756,8 +211876,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-22.11">
-          <h3>29.54. The complex type <code>complexType[siri:AffectedRouteStructure]/RouteLinks#complexType (typedef-22.11)</code>
+        <div class="sect2" id="local-type.typedef-68.11">
+          <h3>29.54. The complex type <code>complexType[siri:AffectedRouteStructure]/RouteLinks#complexType (typedef-68.11)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -211777,7 +211897,7 @@
                       <br/>
                       <code>  /RouteLinks #complexType</code>
                       <br/>
-                      <code>  (typedef-22.11)</code>
+                      <code>  (typedef-68.11)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -211819,8 +211939,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-22.8">
-          <h3>29.55. The complex type <code>complexType[siri:AffectedSectionStructure]/IndirectSectionRef#complexType (typedef-22.8)</code>
+        <div class="sect2" id="local-type.typedef-68.8">
+          <h3>29.55. The complex type <code>complexType[siri:AffectedSectionStructure]/IndirectSectionRef#complexType (typedef-68.8)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -211840,7 +211960,7 @@
                       <br/>
                       <code>  /IndirectSectionRef #complexType</code>
                       <br/>
-                      <code>  (typedef-22.8)</code>
+                      <code>  (typedef-68.8)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -212166,8 +212286,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-22.21">
-          <h3>29.56. The complex type <code>complexType[siri:AffectedStopPlaceComponentStructure]/AffectedFacilities#complexType (typedef-22.21)</code>
+        <div class="sect2" id="local-type.typedef-68.21">
+          <h3>29.56. The complex type <code>complexType[siri:AffectedStopPlaceComponentStructure]/AffectedFacilities#complexType (typedef-68.21)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -212187,7 +212307,7 @@
                       <br/>
                       <code>  /AffectedFacilities #complexType</code>
                       <br/>
-                      <code>  (typedef-22.21)</code>
+                      <code>  (typedef-68.21)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -212229,8 +212349,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-22.18">
-          <h3>29.57. The complex type <code>complexType[siri:AffectedStopPlaceWithoutLineStructure]/AffectedFacilities#complexType (typedef-22.18)</code>
+        <div class="sect2" id="local-type.typedef-68.18">
+          <h3>29.57. The complex type <code>complexType[siri:AffectedStopPlaceWithoutLineStructure]/AffectedFacilities#complexType (typedef-68.18)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -212250,7 +212370,7 @@
                       <br/>
                       <code>  /AffectedFacilities #complexType</code>
                       <br/>
-                      <code>  (typedef-22.18)</code>
+                      <code>  (typedef-68.18)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -212292,8 +212412,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-22.19">
-          <h3>29.58. The complex type <code>complexType[siri:AffectedStopPlaceWithoutLineStructure]/AffectedComponents#complexType (typedef-22.19)</code>
+        <div class="sect2" id="local-type.typedef-68.19">
+          <h3>29.58. The complex type <code>complexType[siri:AffectedStopPlaceWithoutLineStructure]/AffectedComponents#complexType (typedef-68.19)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -212313,7 +212433,7 @@
                       <br/>
                       <code>  /AffectedComponents #complexType</code>
                       <br/>
-                      <code>  (typedef-22.19)</code>
+                      <code>  (typedef-68.19)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -212351,8 +212471,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-22.20">
-          <h3>29.59. The complex type <code>complexType[siri:AffectedStopPlaceWithoutLineStructure]/AffectedNavigationPaths#complexType (typedef-22.20)</code>
+        <div class="sect2" id="local-type.typedef-68.20">
+          <h3>29.59. The complex type <code>complexType[siri:AffectedStopPlaceWithoutLineStructure]/AffectedNavigationPaths#complexType (typedef-68.20)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -212372,7 +212492,7 @@
                       <br/>
                       <code>  /AffectedNavigationPaths #complexType</code>
                       <br/>
-                      <code>  (typedef-22.20)</code>
+                      <code>  (typedef-68.20)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -212414,8 +212534,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-22.17">
-          <h3>29.60. The complex type <code>complexType[siri:AffectedStopPlaceStructure]/Lines#complexType (typedef-22.17)</code>
+        <div class="sect2" id="local-type.typedef-68.17">
+          <h3>29.60. The complex type <code>complexType[siri:AffectedStopPlaceStructure]/Lines#complexType (typedef-68.17)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -212435,7 +212555,7 @@
                       <br/>
                       <code>  /Lines #complexType</code>
                       <br/>
-                      <code>  (typedef-22.17)</code>
+                      <code>  (typedef-68.17)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -212477,8 +212597,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-22.18">
-          <h3>29.61. The complex type <code>complexType[siri:AffectedStopPlaceWithoutLineStructure]/AffectedFacilities#complexType (typedef-22.18)</code>
+        <div class="sect2" id="local-type.typedef-68.18">
+          <h3>29.61. The complex type <code>complexType[siri:AffectedStopPlaceWithoutLineStructure]/AffectedFacilities#complexType (typedef-68.18)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -212498,7 +212618,7 @@
                       <br/>
                       <code>  /AffectedFacilities #complexType</code>
                       <br/>
-                      <code>  (typedef-22.18)</code>
+                      <code>  (typedef-68.18)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -212540,8 +212660,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-22.19">
-          <h3>29.62. The complex type <code>complexType[siri:AffectedStopPlaceWithoutLineStructure]/AffectedComponents#complexType (typedef-22.19)</code>
+        <div class="sect2" id="local-type.typedef-68.19">
+          <h3>29.62. The complex type <code>complexType[siri:AffectedStopPlaceWithoutLineStructure]/AffectedComponents#complexType (typedef-68.19)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -212561,7 +212681,7 @@
                       <br/>
                       <code>  /AffectedComponents #complexType</code>
                       <br/>
-                      <code>  (typedef-22.19)</code>
+                      <code>  (typedef-68.19)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -212599,8 +212719,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-22.20">
-          <h3>29.63. The complex type <code>complexType[siri:AffectedStopPlaceWithoutLineStructure]/AffectedNavigationPaths#complexType (typedef-22.20)</code>
+        <div class="sect2" id="local-type.typedef-68.20">
+          <h3>29.63. The complex type <code>complexType[siri:AffectedStopPlaceWithoutLineStructure]/AffectedNavigationPaths#complexType (typedef-68.20)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -212620,7 +212740,7 @@
                       <br/>
                       <code>  /AffectedNavigationPaths #complexType</code>
                       <br/>
-                      <code>  (typedef-22.20)</code>
+                      <code>  (typedef-68.20)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -212662,8 +212782,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-22.1">
-          <h3>29.64. The complex type <code>complexType[siri:AffectedStopPointWithoutLineStructure]/ConnectionLinks#complexType (typedef-22.1)</code>
+        <div class="sect2" id="local-type.typedef-68.1">
+          <h3>29.64. The complex type <code>complexType[siri:AffectedStopPointWithoutLineStructure]/ConnectionLinks#complexType (typedef-68.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -212683,7 +212803,7 @@
                       <br/>
                       <code>  /ConnectionLinks #complexType</code>
                       <br/>
-                      <code>  (typedef-22.1)</code>
+                      <code>  (typedef-68.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -212725,8 +212845,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-22.2">
-          <h3>29.65. The complex type <code>complexType[siri:AffectedStopPointStructure]/Lines#complexType (typedef-22.2)</code>
+        <div class="sect2" id="local-type.typedef-68.2">
+          <h3>29.65. The complex type <code>complexType[siri:AffectedStopPointStructure]/Lines#complexType (typedef-68.2)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -212746,7 +212866,7 @@
                       <br/>
                       <code>  /Lines #complexType</code>
                       <br/>
-                      <code>  (typedef-22.2)</code>
+                      <code>  (typedef-68.2)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -212788,8 +212908,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-22.1">
-          <h3>29.66. The complex type <code>complexType[siri:AffectedStopPointWithoutLineStructure]/ConnectionLinks#complexType (typedef-22.1)</code>
+        <div class="sect2" id="local-type.typedef-68.1">
+          <h3>29.66. The complex type <code>complexType[siri:AffectedStopPointWithoutLineStructure]/ConnectionLinks#complexType (typedef-68.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -212809,7 +212929,7 @@
                       <br/>
                       <code>  /ConnectionLinks #complexType</code>
                       <br/>
-                      <code>  (typedef-22.1)</code>
+                      <code>  (typedef-68.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -212851,8 +212971,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-22.12">
-          <h3>29.67. The complex type <code>complexType[siri:AffectedVehicleJourneyStructure]/TrainNumbers#complexType (typedef-22.12)</code>
+        <div class="sect2" id="local-type.typedef-68.12">
+          <h3>29.67. The complex type <code>complexType[siri:AffectedVehicleJourneyStructure]/TrainNumbers#complexType (typedef-68.12)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -212872,7 +212992,7 @@
                       <br/>
                       <code>  /TrainNumbers #complexType</code>
                       <br/>
-                      <code>  (typedef-22.12)</code>
+                      <code>  (typedef-68.12)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -212914,8 +213034,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-22.13">
-          <h3>29.68. The complex type <code>complexType[siri:AffectedVehicleJourneyStructure]/JourneyParts#complexType (typedef-22.13)</code>
+        <div class="sect2" id="local-type.typedef-68.13">
+          <h3>29.68. The complex type <code>complexType[siri:AffectedVehicleJourneyStructure]/JourneyParts#complexType (typedef-68.13)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -212935,7 +213055,7 @@
                       <br/>
                       <code>  /JourneyParts #complexType</code>
                       <br/>
-                      <code>  (typedef-22.13)</code>
+                      <code>  (typedef-68.13)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -212977,8 +213097,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-22.14">
-          <h3>29.69. The complex type <code>complexType[siri:AffectedVehicleJourneyStructure]/Calls#complexType (typedef-22.14)</code>
+        <div class="sect2" id="local-type.typedef-68.14">
+          <h3>29.69. The complex type <code>complexType[siri:AffectedVehicleJourneyStructure]/Calls#complexType (typedef-68.14)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -212998,7 +213118,7 @@
                       <br/>
                       <code>  /Calls #complexType</code>
                       <br/>
-                      <code>  (typedef-22.14)</code>
+                      <code>  (typedef-68.14)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -213040,8 +213160,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-22.15">
-          <h3>29.70. The complex type <code>complexType[siri:AffectedVehicleJourneyStructure]/Facilities#complexType (typedef-22.15)</code>
+        <div class="sect2" id="local-type.typedef-68.15">
+          <h3>29.70. The complex type <code>complexType[siri:AffectedVehicleJourneyStructure]/Facilities#complexType (typedef-68.15)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -213061,7 +213181,7 @@
                       <br/>
                       <code>  /Facilities #complexType</code>
                       <br/>
-                      <code>  (typedef-22.15)</code>
+                      <code>  (typedef-68.15)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -213726,12 +213846,12 @@
                 </tr>
                 <tr>
                   <td colspan="1" rowspan="2" class="tableblock halign-left valign-top">
-                    <p id="local-type.typedef-4.2" class="tableblock">
+                    <p id="local-type.typedef-54.2" class="tableblock">
                       <code>element[siri:Predictability]</code>
                       <br/>
                       <code>  #simpleType</code>
                       <br/>
-                      <code>  (typedef-4.2)</code>
+                      <code>  (typedef-54.2)</code>
                     </p>
                   </td>
                   <td colspan="2" rowspan="1" class="tableblock halign-left valign-top">
@@ -213776,12 +213896,12 @@
                 </tr>
                 <tr>
                   <td colspan="1" rowspan="2" class="tableblock halign-left valign-top">
-                    <p id="local-type.typedef-4.1" class="tableblock">
+                    <p id="local-type.typedef-54.1" class="tableblock">
                       <code>element[siri:VerificationStatus]</code>
                       <br/>
                       <code>  #simpleType</code>
                       <br/>
-                      <code>  (typedef-4.1)</code>
+                      <code>  (typedef-54.1)</code>
                     </p>
                   </td>
                   <td colspan="2" rowspan="1" class="tableblock halign-left valign-top">
@@ -220791,7 +220911,7 @@
                   </td>
                 </tr>
                 <tr>
-                  <td colspan="1" rowspan="4" class="tableblock halign-left valign-top">
+                  <td colspan="1" rowspan="5" class="tableblock halign-left valign-top">
                     <a shape="rect" href="#group.siri:JourneyInfoGroup" title="siri:JourneyInfoGroup">siri:JourneyInfoGroup</a>
                   </td>
                   <td colspan="2" rowspan="1" class="tableblock halign-left valign-top">
@@ -220812,6 +220932,26 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock darkbrown">For train services with named journeys. Train name, e.g. “West Coast Express”. If omitted: No train name. Inherited property. (Unbounded since SIRI 2.0)</p>
+                  </td>
+                </tr>
+                <tr>
+                  <td colspan="2" rowspan="1" class="tableblock halign-left valign-top">
+                    <p class="tableblock">
+                      <code>siri:DeadRun</code>
+                    </p>
+                  </td>
+                  <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
+                    <p class="tableblock">
+                      <span title="optional, single">0:1</span>
+                    </p>
+                  </td>
+                  <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
+                    <p class="tableblock">
+                      <em>xs:boolean</em>
+                    </p>
+                  </td>
+                  <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
+                    <p class="tableblock darkbrown">Allows to flag if the VehicleJourney is a dead run, so it is clear that only there is no expectation of an associated service to it. +v2.3</p>
                   </td>
                 </tr>
                 <tr>
@@ -223576,7 +223716,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-58.1" title="local-type: typedef-58.1">local-type: typedef-58.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-36.1" title="local-type: typedef-36.1">local-type: typedef-36.1</a>
                       </em>
                     </p>
                   </td>
@@ -223600,7 +223740,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-58.2" title="local-type: typedef-58.2">local-type: typedef-58.2</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-36.2" title="local-type: typedef-36.2">local-type: typedef-36.2</a>
                       </em>
                     </p>
                   </td>
@@ -223744,7 +223884,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-58.3" title="local-type: typedef-58.3">local-type: typedef-58.3</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-36.3" title="local-type: typedef-36.3">local-type: typedef-36.3</a>
                       </em>
                     </p>
                   </td>
@@ -223954,7 +224094,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-55.1" title="local-type: typedef-55.1">local-type: typedef-55.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-35.1" title="local-type: typedef-35.1">local-type: typedef-35.1</a>
                       </em>
                     </p>
                   </td>
@@ -223978,7 +224118,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-55.2" title="local-type: typedef-55.2">local-type: typedef-55.2</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-35.2" title="local-type: typedef-35.2">local-type: typedef-35.2</a>
                       </em>
                     </p>
                   </td>
@@ -224142,8 +224282,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-58.1">
-          <h3>39.7. The complex type <code>complexType[siri:AnnotatedLineStructure]/Destinations#complexType (typedef-58.1)</code>
+        <div class="sect2" id="local-type.typedef-36.1">
+          <h3>39.7. The complex type <code>complexType[siri:AnnotatedLineStructure]/Destinations#complexType (typedef-36.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -224163,7 +224303,7 @@
                       <br/>
                       <code>  /Destinations #complexType</code>
                       <br/>
-                      <code>  (typedef-58.1)</code>
+                      <code>  (typedef-36.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -224206,8 +224346,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-58.2">
-          <h3>39.8. The complex type <code>complexType[siri:AnnotatedLineStructure]/Directions#complexType (typedef-58.2)</code>
+        <div class="sect2" id="local-type.typedef-36.2">
+          <h3>39.8. The complex type <code>complexType[siri:AnnotatedLineStructure]/Directions#complexType (typedef-36.2)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -224227,7 +224367,7 @@
                       <br/>
                       <code>  /Directions #complexType</code>
                       <br/>
-                      <code>  (typedef-58.2)</code>
+                      <code>  (typedef-36.2)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -224269,8 +224409,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-58.3">
-          <h3>39.9. The complex type <code>complexType[siri:RouteDirectionStructure]/JourneyPatterns#complexType (typedef-58.3)</code>
+        <div class="sect2" id="local-type.typedef-36.3">
+          <h3>39.9. The complex type <code>complexType[siri:RouteDirectionStructure]/JourneyPatterns#complexType (typedef-36.3)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -224290,7 +224430,7 @@
                       <br/>
                       <code>  /JourneyPatterns #complexType</code>
                       <br/>
-                      <code>  (typedef-58.3)</code>
+                      <code>  (typedef-36.3)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -224320,7 +224460,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-58.4" title="local-type: typedef-58.4">local-type: typedef-58.4</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-36.4" title="local-type: typedef-36.4">local-type: typedef-36.4</a>
                       </em>
                     </p>
                   </td>
@@ -224332,8 +224472,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-58.4">
-          <h3>39.10. The complex type <code>complexType[siri:RouteDirectionStructure]/JourneyPatterns/JourneyPattern#complexType (typedef-58.4)</code>
+        <div class="sect2" id="local-type.typedef-36.4">
+          <h3>39.10. The complex type <code>complexType[siri:RouteDirectionStructure]/JourneyPatterns/JourneyPattern#complexType (typedef-36.4)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -224353,7 +224493,7 @@
                       <br/>
                       <code>  /JourneyPatterns/JourneyPattern #complexType</code>
                       <br/>
-                      <code>  (typedef-58.4)</code>
+                      <code>  (typedef-36.4)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -224428,7 +224568,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-58.5" title="local-type: typedef-58.5">local-type: typedef-58.5</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-36.5" title="local-type: typedef-36.5">local-type: typedef-36.5</a>
                       </em>
                     </p>
                   </td>
@@ -224440,8 +224580,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-58.5">
-          <h3>39.11. The complex type <code>complexType[siri:RouteDirectionStructure]/JourneyPatterns/JourneyPattern/StopsInPattern#complexType (typedef-58.5)</code>
+        <div class="sect2" id="local-type.typedef-36.5">
+          <h3>39.11. The complex type <code>complexType[siri:RouteDirectionStructure]/JourneyPatterns/JourneyPattern/StopsInPattern#complexType (typedef-36.5)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -224461,7 +224601,7 @@
                       <br/>
                       <code>  /JourneyPatterns/JourneyPattern/StopsInPattern #complexType</code>
                       <br/>
-                      <code>  (typedef-58.5)</code>
+                      <code>  (typedef-36.5)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -224503,8 +224643,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-55.1">
-          <h3>39.12. The complex type <code>complexType[siri:AnnotatedStopPointStructure]/Features#complexType (typedef-55.1)</code>
+        <div class="sect2" id="local-type.typedef-35.1">
+          <h3>39.12. The complex type <code>complexType[siri:AnnotatedStopPointStructure]/Features#complexType (typedef-35.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -224524,7 +224664,7 @@
                       <br/>
                       <code>  /Features #complexType</code>
                       <br/>
-                      <code>  (typedef-55.1)</code>
+                      <code>  (typedef-35.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -224610,8 +224750,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-55.2">
-          <h3>39.13. The complex type <code>complexType[siri:AnnotatedStopPointStructure]/Lines#complexType (typedef-55.2)</code>
+        <div class="sect2" id="local-type.typedef-35.2">
+          <h3>39.13. The complex type <code>complexType[siri:AnnotatedStopPointStructure]/Lines#complexType (typedef-35.2)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -224631,7 +224771,7 @@
                       <br/>
                       <code>  /Lines #complexType</code>
                       <br/>
-                      <code>  (typedef-55.2)</code>
+                      <code>  (typedef-35.2)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -224919,7 +225059,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-55.1" title="local-type: typedef-55.1">local-type: typedef-55.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-35.1" title="local-type: typedef-35.1">local-type: typedef-35.1</a>
                       </em>
                     </p>
                   </td>
@@ -224943,7 +225083,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-55.2" title="local-type: typedef-55.2">local-type: typedef-55.2</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-35.2" title="local-type: typedef-35.2">local-type: typedef-35.2</a>
                       </em>
                     </p>
                   </td>
@@ -225002,8 +225142,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-55.1">
-          <h3>40.3. The complex type <code>complexType[siri:AnnotatedStopPointStructure]/Features#complexType (typedef-55.1)</code>
+        <div class="sect2" id="local-type.typedef-35.1">
+          <h3>40.3. The complex type <code>complexType[siri:AnnotatedStopPointStructure]/Features#complexType (typedef-35.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -225023,7 +225163,7 @@
                       <br/>
                       <code>  /Features #complexType</code>
                       <br/>
-                      <code>  (typedef-55.1)</code>
+                      <code>  (typedef-35.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -225109,8 +225249,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-55.2">
-          <h3>40.4. The complex type <code>complexType[siri:AnnotatedStopPointStructure]/Lines#complexType (typedef-55.2)</code>
+        <div class="sect2" id="local-type.typedef-35.2">
+          <h3>40.4. The complex type <code>complexType[siri:AnnotatedStopPointStructure]/Lines#complexType (typedef-35.2)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -225130,7 +225270,7 @@
                       <br/>
                       <code>  /Lines #complexType</code>
                       <br/>
-                      <code>  (typedef-55.2)</code>
+                      <code>  (typedef-35.2)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -226254,7 +226394,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-74.1" title="local-type: typedef-74.1">local-type: typedef-74.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-86.1" title="local-type: typedef-86.1">local-type: typedef-86.1</a>
                       </em>
                     </p>
                   </td>
@@ -226404,7 +226544,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-74.2" title="local-type: typedef-74.2">local-type: typedef-74.2</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-86.2" title="local-type: typedef-86.2">local-type: typedef-86.2</a>
                       </em>
                     </p>
                   </td>
@@ -226456,7 +226596,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-74.3" title="local-type: typedef-74.3">local-type: typedef-74.3</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-86.3" title="local-type: typedef-86.3">local-type: typedef-86.3</a>
                       </em>
                     </p>
                   </td>
@@ -227516,7 +227656,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-74.7" title="local-type: typedef-74.7">local-type: typedef-74.7</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-86.7" title="local-type: typedef-86.7">local-type: typedef-86.7</a>
                       </em>
                     </p>
                   </td>
@@ -228426,7 +228566,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-74.1" title="local-type: typedef-74.1">local-type: typedef-74.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-86.1" title="local-type: typedef-86.1">local-type: typedef-86.1</a>
                       </em>
                     </p>
                   </td>
@@ -228757,7 +228897,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-74.4" title="local-type: typedef-74.4">local-type: typedef-74.4</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-86.4" title="local-type: typedef-86.4">local-type: typedef-86.4</a>
                       </em>
                     </p>
                   </td>
@@ -228781,7 +228921,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-74.5" title="local-type: typedef-74.5">local-type: typedef-74.5</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-86.5" title="local-type: typedef-86.5">local-type: typedef-86.5</a>
                       </em>
                     </p>
                   </td>
@@ -228805,7 +228945,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-74.6" title="local-type: typedef-74.6">local-type: typedef-74.6</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-86.6" title="local-type: typedef-86.6">local-type: typedef-86.6</a>
                       </em>
                     </p>
                   </td>
@@ -229177,8 +229317,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-74.3">
-          <h3>41.23. The complex type <code>element[siri:ProductionTimetableCapabilitiesRequest]#complexType (typedef-74.3)</code>
+        <div class="sect2" id="local-type.typedef-86.3">
+          <h3>41.23. The complex type <code>element[siri:ProductionTimetableCapabilitiesRequest]#complexType (typedef-86.3)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -229198,7 +229338,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-74.3)</code>
+                      <code>  (typedef-86.3)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -229348,8 +229488,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-74.7">
-          <h3>41.24. The complex type <code>element[siri:ProductionTimetablePermissions]#complexType (typedef-74.7)</code>
+        <div class="sect2" id="local-type.typedef-86.7">
+          <h3>41.24. The complex type <code>element[siri:ProductionTimetablePermissions]#complexType (typedef-86.7)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -229369,7 +229509,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-74.7)</code>
+                      <code>  (typedef-86.7)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -229444,8 +229584,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-74.2">
-          <h3>41.25. The complex type <code>element[siri:ProductionTimetableSubscriptionRequest]#complexType (typedef-74.2)</code>
+        <div class="sect2" id="local-type.typedef-86.2">
+          <h3>41.25. The complex type <code>element[siri:ProductionTimetableSubscriptionRequest]#complexType (typedef-86.2)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -229465,7 +229605,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-74.2)</code>
+                      <code>  (typedef-86.2)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -229662,8 +229802,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-74.1">
-          <h3>41.26. The complex type <code>group[siri:ProductionTimetableTopicGroup]/Lines#complexType (typedef-74.1)</code>
+        <div class="sect2" id="local-type.typedef-86.1">
+          <h3>41.26. The complex type <code>group[siri:ProductionTimetableTopicGroup]/Lines#complexType (typedef-86.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -229683,7 +229823,7 @@
                       <br/>
                       <code>  /Lines #complexType</code>
                       <br/>
-                      <code>  (typedef-74.1)</code>
+                      <code>  (typedef-86.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -229725,8 +229865,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-74.2">
-          <h3>41.27. The complex type <code>element[siri:ProductionTimetableSubscriptionRequest]#complexType (typedef-74.2)</code>
+        <div class="sect2" id="local-type.typedef-86.2">
+          <h3>41.27. The complex type <code>element[siri:ProductionTimetableSubscriptionRequest]#complexType (typedef-86.2)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -229746,7 +229886,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-74.2)</code>
+                      <code>  (typedef-86.2)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -229943,8 +230083,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-74.3">
-          <h3>41.28. The complex type <code>element[siri:ProductionTimetableCapabilitiesRequest]#complexType (typedef-74.3)</code>
+        <div class="sect2" id="local-type.typedef-86.3">
+          <h3>41.28. The complex type <code>element[siri:ProductionTimetableCapabilitiesRequest]#complexType (typedef-86.3)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -229964,7 +230104,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-74.3)</code>
+                      <code>  (typedef-86.3)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -230114,8 +230254,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-74.7">
-          <h3>41.29. The complex type <code>element[siri:ProductionTimetablePermissions]#complexType (typedef-74.7)</code>
+        <div class="sect2" id="local-type.typedef-86.7">
+          <h3>41.29. The complex type <code>element[siri:ProductionTimetablePermissions]#complexType (typedef-86.7)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -230135,7 +230275,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-74.7)</code>
+                      <code>  (typedef-86.7)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -230210,8 +230350,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-74.1">
-          <h3>41.30. The complex type <code>group[siri:ProductionTimetableTopicGroup]/Lines#complexType (typedef-74.1)</code>
+        <div class="sect2" id="local-type.typedef-86.1">
+          <h3>41.30. The complex type <code>group[siri:ProductionTimetableTopicGroup]/Lines#complexType (typedef-86.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -230231,7 +230371,7 @@
                       <br/>
                       <code>  /Lines #complexType</code>
                       <br/>
-                      <code>  (typedef-74.1)</code>
+                      <code>  (typedef-86.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -230273,8 +230413,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-74.4">
-          <h3>41.31. The complex type <code>complexType[siri:ProductionTimetableServiceCapabilitiesStructure]/TopicFiltering#complexType (typedef-74.4)</code>
+        <div class="sect2" id="local-type.typedef-86.4">
+          <h3>41.31. The complex type <code>complexType[siri:ProductionTimetableServiceCapabilitiesStructure]/TopicFiltering#complexType (typedef-86.4)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -230294,7 +230434,7 @@
                       <br/>
                       <code>  /TopicFiltering #complexType</code>
                       <br/>
-                      <code>  (typedef-74.4)</code>
+                      <code>  (typedef-86.4)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -230491,8 +230631,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-74.5">
-          <h3>41.32. The complex type <code>complexType[siri:ProductionTimetableServiceCapabilitiesStructure]/RequestPolicy#complexType (typedef-74.5)</code>
+        <div class="sect2" id="local-type.typedef-86.5">
+          <h3>41.32. The complex type <code>complexType[siri:ProductionTimetableServiceCapabilitiesStructure]/RequestPolicy#complexType (typedef-86.5)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -230512,7 +230652,7 @@
                       <br/>
                       <code>  /RequestPolicy #complexType</code>
                       <br/>
-                      <code>  (typedef-74.5)</code>
+                      <code>  (typedef-86.5)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -230656,8 +230796,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-74.6">
-          <h3>41.33. The complex type <code>complexType[siri:ProductionTimetableServiceCapabilitiesStructure]/SubscriptionPolicy#complexType (typedef-74.6)</code>
+        <div class="sect2" id="local-type.typedef-86.6">
+          <h3>41.33. The complex type <code>complexType[siri:ProductionTimetableServiceCapabilitiesStructure]/SubscriptionPolicy#complexType (typedef-86.6)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -230677,7 +230817,7 @@
                       <br/>
                       <code>  /SubscriptionPolicy #complexType</code>
                       <br/>
-                      <code>  (typedef-74.6)</code>
+                      <code>  (typedef-86.6)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -231392,7 +231532,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-77.3" title="local-type: typedef-77.3">local-type: typedef-77.3</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-72.3" title="local-type: typedef-72.3">local-type: typedef-72.3</a>
                       </em>
                     </p>
                   </td>
@@ -232258,7 +232398,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-77.2" title="local-type: typedef-77.2">local-type: typedef-77.2</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-72.2" title="local-type: typedef-72.2">local-type: typedef-72.2</a>
                       </em>
                     </p>
                   </td>
@@ -232571,7 +232711,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-77.1" title="local-type: typedef-77.1">local-type: typedef-77.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-72.1" title="local-type: typedef-72.1">local-type: typedef-72.1</a>
                       </em>
                     </p>
                   </td>
@@ -232945,7 +233085,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-77.2" title="local-type: typedef-77.2">local-type: typedef-77.2</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-72.2" title="local-type: typedef-72.2">local-type: typedef-72.2</a>
                       </em>
                     </p>
                   </td>
@@ -234110,7 +234250,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-77.8" title="local-type: typedef-77.8">local-type: typedef-77.8</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-72.8" title="local-type: typedef-72.8">local-type: typedef-72.8</a>
                       </em>
                     </p>
                   </td>
@@ -234618,7 +234758,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-77.3" title="local-type: typedef-77.3">local-type: typedef-77.3</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-72.3" title="local-type: typedef-72.3">local-type: typedef-72.3</a>
                       </em>
                     </p>
                   </td>
@@ -235453,7 +235593,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-77.2" title="local-type: typedef-77.2">local-type: typedef-77.2</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-72.2" title="local-type: typedef-72.2">local-type: typedef-72.2</a>
                       </em>
                     </p>
                   </td>
@@ -235766,7 +235906,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-77.1" title="local-type: typedef-77.1">local-type: typedef-77.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-72.1" title="local-type: typedef-72.1">local-type: typedef-72.1</a>
                       </em>
                     </p>
                   </td>
@@ -235991,7 +236131,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-77.4" title="local-type: typedef-77.4">local-type: typedef-77.4</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-72.4" title="local-type: typedef-72.4">local-type: typedef-72.4</a>
                       </em>
                     </p>
                   </td>
@@ -236015,7 +236155,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-77.5" title="local-type: typedef-77.5">local-type: typedef-77.5</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-72.5" title="local-type: typedef-72.5">local-type: typedef-72.5</a>
                       </em>
                     </p>
                   </td>
@@ -236063,7 +236203,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-77.6" title="local-type: typedef-77.6">local-type: typedef-77.6</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-72.6" title="local-type: typedef-72.6">local-type: typedef-72.6</a>
                       </em>
                     </p>
                   </td>
@@ -236087,7 +236227,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-77.7" title="local-type: typedef-77.7">local-type: typedef-77.7</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-72.7" title="local-type: typedef-72.7">local-type: typedef-72.7</a>
                       </em>
                     </p>
                   </td>
@@ -236246,7 +236386,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-61.1" title="local-type: typedef-61.1">local-type: typedef-61.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-44.1" title="local-type: typedef-44.1">local-type: typedef-44.1</a>
                       </em>
                     </p>
                   </td>
@@ -236280,7 +236420,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-2.2" title="local-type: typedef-2.2">local-type: typedef-2.2</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-65.2" title="local-type: typedef-65.2">local-type: typedef-65.2</a>
                       </em>
                     </p>
                   </td>
@@ -236309,7 +236449,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-2.1" title="local-type: typedef-2.1">local-type: typedef-2.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-65.1" title="local-type: typedef-65.1">local-type: typedef-65.1</a>
                       </em>
                     </p>
                   </td>
@@ -236565,8 +236705,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-77.8">
-          <h3>42.33. The complex type <code>element[siri:SituationExchangePermissions]#complexType (typedef-77.8)</code>
+        <div class="sect2" id="local-type.typedef-72.8">
+          <h3>42.33. The complex type <code>element[siri:SituationExchangePermissions]#complexType (typedef-72.8)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -236586,7 +236726,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-77.8)</code>
+                      <code>  (typedef-72.8)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -236660,8 +236800,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-77.3">
-          <h3>42.34. The complex type <code>group[siri:SituationExchangePayloadGroup]/Situations#complexType (typedef-77.3)</code>
+        <div class="sect2" id="local-type.typedef-72.3">
+          <h3>42.34. The complex type <code>group[siri:SituationExchangePayloadGroup]/Situations#complexType (typedef-72.3)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -236681,7 +236821,7 @@
                       <br/>
                       <code>  /Situations #complexType</code>
                       <br/>
-                      <code>  (typedef-77.3)</code>
+                      <code>  (typedef-72.3)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -236744,8 +236884,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-77.2">
-          <h3>42.35. The complex type <code>group[siri:SituationNetworkFilterGroup]/Lines#complexType (typedef-77.2)</code>
+        <div class="sect2" id="local-type.typedef-72.2">
+          <h3>42.35. The complex type <code>group[siri:SituationNetworkFilterGroup]/Lines#complexType (typedef-72.2)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -236765,7 +236905,7 @@
                       <br/>
                       <code>  /Lines #complexType</code>
                       <br/>
-                      <code>  (typedef-77.2)</code>
+                      <code>  (typedef-72.2)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -236807,8 +236947,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-77.1">
-          <h3>42.36. The complex type <code>group[siri:SituationExchangeTopicGroup]/SituationRoadFilter#complexType (typedef-77.1)</code>
+        <div class="sect2" id="local-type.typedef-72.1">
+          <h3>42.36. The complex type <code>group[siri:SituationExchangeTopicGroup]/SituationRoadFilter#complexType (typedef-72.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -236828,7 +236968,7 @@
                       <br/>
                       <code>  /SituationRoadFilter #complexType</code>
                       <br/>
-                      <code>  (typedef-77.1)</code>
+                      <code>  (typedef-72.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -236870,8 +237010,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-77.2">
-          <h3>42.37. The complex type <code>group[siri:SituationNetworkFilterGroup]/Lines#complexType (typedef-77.2)</code>
+        <div class="sect2" id="local-type.typedef-72.2">
+          <h3>42.37. The complex type <code>group[siri:SituationNetworkFilterGroup]/Lines#complexType (typedef-72.2)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -236891,7 +237031,7 @@
                       <br/>
                       <code>  /Lines #complexType</code>
                       <br/>
-                      <code>  (typedef-77.2)</code>
+                      <code>  (typedef-72.2)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -236933,8 +237073,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-77.8">
-          <h3>42.38. The complex type <code>element[siri:SituationExchangePermissions]#complexType (typedef-77.8)</code>
+        <div class="sect2" id="local-type.typedef-72.8">
+          <h3>42.38. The complex type <code>element[siri:SituationExchangePermissions]#complexType (typedef-72.8)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -236954,7 +237094,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-77.8)</code>
+                      <code>  (typedef-72.8)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -237028,8 +237168,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-77.3">
-          <h3>42.39. The complex type <code>group[siri:SituationExchangePayloadGroup]/Situations#complexType (typedef-77.3)</code>
+        <div class="sect2" id="local-type.typedef-72.3">
+          <h3>42.39. The complex type <code>group[siri:SituationExchangePayloadGroup]/Situations#complexType (typedef-72.3)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -237049,7 +237189,7 @@
                       <br/>
                       <code>  /Situations #complexType</code>
                       <br/>
-                      <code>  (typedef-77.3)</code>
+                      <code>  (typedef-72.3)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -237112,8 +237252,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-77.2">
-          <h3>42.40. The complex type <code>group[siri:SituationNetworkFilterGroup]/Lines#complexType (typedef-77.2)</code>
+        <div class="sect2" id="local-type.typedef-72.2">
+          <h3>42.40. The complex type <code>group[siri:SituationNetworkFilterGroup]/Lines#complexType (typedef-72.2)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -237133,7 +237273,7 @@
                       <br/>
                       <code>  /Lines #complexType</code>
                       <br/>
-                      <code>  (typedef-77.2)</code>
+                      <code>  (typedef-72.2)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -237175,8 +237315,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-77.1">
-          <h3>42.41. The complex type <code>group[siri:SituationExchangeTopicGroup]/SituationRoadFilter#complexType (typedef-77.1)</code>
+        <div class="sect2" id="local-type.typedef-72.1">
+          <h3>42.41. The complex type <code>group[siri:SituationExchangeTopicGroup]/SituationRoadFilter#complexType (typedef-72.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -237196,7 +237336,7 @@
                       <br/>
                       <code>  /SituationRoadFilter #complexType</code>
                       <br/>
-                      <code>  (typedef-77.1)</code>
+                      <code>  (typedef-72.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -237238,8 +237378,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-77.4">
-          <h3>42.42. The complex type <code>complexType[siri:SituationExchangeServiceCapabilitiesStructure]/TopicFiltering#complexType (typedef-77.4)</code>
+        <div class="sect2" id="local-type.typedef-72.4">
+          <h3>42.42. The complex type <code>complexType[siri:SituationExchangeServiceCapabilitiesStructure]/TopicFiltering#complexType (typedef-72.4)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -237259,7 +237399,7 @@
                       <br/>
                       <code>  /TopicFiltering #complexType</code>
                       <br/>
-                      <code>  (typedef-77.4)</code>
+                      <code>  (typedef-72.4)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -237608,8 +237748,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-77.5">
-          <h3>42.43. The complex type <code>complexType[siri:SituationExchangeServiceCapabilitiesStructure]/RequestPolicy#complexType (typedef-77.5)</code>
+        <div class="sect2" id="local-type.typedef-72.5">
+          <h3>42.43. The complex type <code>complexType[siri:SituationExchangeServiceCapabilitiesStructure]/RequestPolicy#complexType (typedef-72.5)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -237629,7 +237769,7 @@
                       <br/>
                       <code>  /RequestPolicy #complexType</code>
                       <br/>
-                      <code>  (typedef-77.5)</code>
+                      <code>  (typedef-72.5)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -237801,8 +237941,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-77.6">
-          <h3>42.44. The complex type <code>complexType[siri:SituationExchangeServiceCapabilitiesStructure]/AccessControl#complexType (typedef-77.6)</code>
+        <div class="sect2" id="local-type.typedef-72.6">
+          <h3>42.44. The complex type <code>complexType[siri:SituationExchangeServiceCapabilitiesStructure]/AccessControl#complexType (typedef-72.6)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -237822,7 +237962,7 @@
                       <br/>
                       <code>  /AccessControl #complexType</code>
                       <br/>
-                      <code>  (typedef-77.6)</code>
+                      <code>  (typedef-72.6)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -237923,8 +238063,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-77.7">
-          <h3>42.45. The complex type <code>complexType[siri:SituationExchangeServiceCapabilitiesStructure]/ResponseFeatures#complexType (typedef-77.7)</code>
+        <div class="sect2" id="local-type.typedef-72.7">
+          <h3>42.45. The complex type <code>complexType[siri:SituationExchangeServiceCapabilitiesStructure]/ResponseFeatures#complexType (typedef-72.7)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -237944,7 +238084,7 @@
                       <br/>
                       <code>  /ResponseFeatures #complexType</code>
                       <br/>
-                      <code>  (typedef-77.7)</code>
+                      <code>  (typedef-72.7)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -237958,8 +238098,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-61.1">
-          <h3>42.46. The complex type <code>complexType[siri:AbstractPermissionStructure]/GeneralCapabilities#complexType (typedef-61.1)</code>
+        <div class="sect2" id="local-type.typedef-44.1">
+          <h3>42.46. The complex type <code>complexType[siri:AbstractPermissionStructure]/GeneralCapabilities#complexType (typedef-44.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -237979,7 +238119,7 @@
                       <br/>
                       <code>  /GeneralCapabilities #complexType</code>
                       <br/>
-                      <code>  (typedef-61.1)</code>
+                      <code>  (typedef-44.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -238047,8 +238187,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-2.2">
-          <h3>42.47. The complex type <code>element[siri:OperatorPermissions]#complexType (typedef-2.2)</code>
+        <div class="sect2" id="local-type.typedef-65.2">
+          <h3>42.47. The complex type <code>element[siri:OperatorPermissions]#complexType (typedef-65.2)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -238068,7 +238208,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-2.2)</code>
+                      <code>  (typedef-65.2)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -238153,8 +238293,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-2.1">
-          <h3>42.48. The complex type <code>element[siri:LinePermissions]#complexType (typedef-2.1)</code>
+        <div class="sect2" id="local-type.typedef-65.1">
+          <h3>42.48. The complex type <code>element[siri:LinePermissions]#complexType (typedef-65.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -238174,7 +238314,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-2.1)</code>
+                      <code>  (typedef-65.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -239709,7 +239849,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-75.1" title="local-type: typedef-75.1">local-type: typedef-75.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-79.1" title="local-type: typedef-79.1">local-type: typedef-79.1</a>
                       </em>
                     </p>
                   </td>
@@ -242262,7 +242402,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-75.5" title="local-type: typedef-75.5">local-type: typedef-75.5</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-79.5" title="local-type: typedef-79.5">local-type: typedef-79.5</a>
                       </em>
                     </p>
                   </td>
@@ -243594,7 +243734,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-75.1" title="local-type: typedef-75.1">local-type: typedef-75.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-79.1" title="local-type: typedef-79.1">local-type: typedef-79.1</a>
                       </em>
                     </p>
                   </td>
@@ -244273,7 +244413,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-75.1" title="local-type: typedef-75.1">local-type: typedef-75.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-79.1" title="local-type: typedef-79.1">local-type: typedef-79.1</a>
                       </em>
                     </p>
                   </td>
@@ -244413,7 +244553,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-75.2" title="local-type: typedef-75.2">local-type: typedef-75.2</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-79.2" title="local-type: typedef-79.2">local-type: typedef-79.2</a>
                       </em>
                     </p>
                   </td>
@@ -244437,7 +244577,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-75.3" title="local-type: typedef-75.3">local-type: typedef-75.3</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-79.3" title="local-type: typedef-79.3">local-type: typedef-79.3</a>
                       </em>
                     </p>
                   </td>
@@ -244509,7 +244649,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-75.4" title="local-type: typedef-75.4">local-type: typedef-75.4</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-79.4" title="local-type: typedef-79.4">local-type: typedef-79.4</a>
                       </em>
                     </p>
                   </td>
@@ -244643,7 +244783,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-61.1" title="local-type: typedef-61.1">local-type: typedef-61.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-44.1" title="local-type: typedef-44.1">local-type: typedef-44.1</a>
                       </em>
                     </p>
                   </td>
@@ -244677,7 +244817,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-2.2" title="local-type: typedef-2.2">local-type: typedef-2.2</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-65.2" title="local-type: typedef-65.2">local-type: typedef-65.2</a>
                       </em>
                     </p>
                   </td>
@@ -244706,7 +244846,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-2.1" title="local-type: typedef-2.1">local-type: typedef-2.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-65.1" title="local-type: typedef-65.1">local-type: typedef-65.1</a>
                       </em>
                     </p>
                   </td>
@@ -244734,7 +244874,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-75.6" title="local-type: typedef-75.6">local-type: typedef-75.6</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-79.6" title="local-type: typedef-79.6">local-type: typedef-79.6</a>
                       </em>
                     </p>
                   </td>
@@ -245437,8 +245577,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-75.5">
-          <h3>43.47. The complex type <code>element[siri:StopMonitoringPermissions]#complexType (typedef-75.5)</code>
+        <div class="sect2" id="local-type.typedef-79.5">
+          <h3>43.47. The complex type <code>element[siri:StopMonitoringPermissions]#complexType (typedef-79.5)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -245458,7 +245598,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-75.5)</code>
+                      <code>  (typedef-79.5)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -245532,8 +245672,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-75.1">
-          <h3>43.48. The complex type <code>group[siri:StopMonitoringRequestPolicyGroup]/MaximumNumberOfCalls#complexType (typedef-75.1)</code>
+        <div class="sect2" id="local-type.typedef-79.1">
+          <h3>43.48. The complex type <code>group[siri:StopMonitoringRequestPolicyGroup]/MaximumNumberOfCalls#complexType (typedef-79.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -245553,7 +245693,7 @@
                       <br/>
                       <code>  /MaximumNumberOfCalls #complexType</code>
                       <br/>
-                      <code>  (typedef-75.1)</code>
+                      <code>  (typedef-79.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -245613,8 +245753,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-75.5">
-          <h3>43.49. The complex type <code>element[siri:StopMonitoringPermissions]#complexType (typedef-75.5)</code>
+        <div class="sect2" id="local-type.typedef-79.5">
+          <h3>43.49. The complex type <code>element[siri:StopMonitoringPermissions]#complexType (typedef-79.5)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -245634,7 +245774,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-75.5)</code>
+                      <code>  (typedef-79.5)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -245708,8 +245848,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-75.1">
-          <h3>43.50. The complex type <code>group[siri:StopMonitoringRequestPolicyGroup]/MaximumNumberOfCalls#complexType (typedef-75.1)</code>
+        <div class="sect2" id="local-type.typedef-79.1">
+          <h3>43.50. The complex type <code>group[siri:StopMonitoringRequestPolicyGroup]/MaximumNumberOfCalls#complexType (typedef-79.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -245729,7 +245869,7 @@
                       <br/>
                       <code>  /MaximumNumberOfCalls #complexType</code>
                       <br/>
-                      <code>  (typedef-75.1)</code>
+                      <code>  (typedef-79.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -245789,8 +245929,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-75.1">
-          <h3>43.51. The complex type <code>group[siri:StopMonitoringRequestPolicyGroup]/MaximumNumberOfCalls#complexType (typedef-75.1)</code>
+        <div class="sect2" id="local-type.typedef-79.1">
+          <h3>43.51. The complex type <code>group[siri:StopMonitoringRequestPolicyGroup]/MaximumNumberOfCalls#complexType (typedef-79.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -245810,7 +245950,7 @@
                       <br/>
                       <code>  /MaximumNumberOfCalls #complexType</code>
                       <br/>
-                      <code>  (typedef-75.1)</code>
+                      <code>  (typedef-79.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -245870,8 +246010,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-75.2">
-          <h3>43.52. The complex type <code>complexType[siri:StopMonitoringServiceCapabilitiesStructure]/TopicFiltering#complexType (typedef-75.2)</code>
+        <div class="sect2" id="local-type.typedef-79.2">
+          <h3>43.52. The complex type <code>complexType[siri:StopMonitoringServiceCapabilitiesStructure]/TopicFiltering#complexType (typedef-79.2)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -245891,7 +246031,7 @@
                       <br/>
                       <code>  /TopicFiltering #complexType</code>
                       <br/>
-                      <code>  (typedef-75.2)</code>
+                      <code>  (typedef-79.2)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -246084,8 +246224,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-75.3">
-          <h3>43.53. The complex type <code>complexType[siri:StopMonitoringServiceCapabilitiesStructure]/RequestPolicy#complexType (typedef-75.3)</code>
+        <div class="sect2" id="local-type.typedef-79.3">
+          <h3>43.53. The complex type <code>complexType[siri:StopMonitoringServiceCapabilitiesStructure]/RequestPolicy#complexType (typedef-79.3)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -246105,7 +246245,7 @@
                       <br/>
                       <code>  /RequestPolicy #complexType</code>
                       <br/>
-                      <code>  (typedef-75.3)</code>
+                      <code>  (typedef-79.3)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -246445,8 +246585,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-75.4">
-          <h3>43.54. The complex type <code>complexType[siri:StopMonitoringServiceCapabilitiesStructure]/ResponseFeatures#complexType (typedef-75.4)</code>
+        <div class="sect2" id="local-type.typedef-79.4">
+          <h3>43.54. The complex type <code>complexType[siri:StopMonitoringServiceCapabilitiesStructure]/ResponseFeatures#complexType (typedef-79.4)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -246466,7 +246606,7 @@
                       <br/>
                       <code>  /ResponseFeatures #complexType</code>
                       <br/>
-                      <code>  (typedef-75.4)</code>
+                      <code>  (typedef-79.4)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -246526,8 +246666,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-61.1">
-          <h3>43.55. The complex type <code>complexType[siri:AbstractPermissionStructure]/GeneralCapabilities#complexType (typedef-61.1)</code>
+        <div class="sect2" id="local-type.typedef-44.1">
+          <h3>43.55. The complex type <code>complexType[siri:AbstractPermissionStructure]/GeneralCapabilities#complexType (typedef-44.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -246547,7 +246687,7 @@
                       <br/>
                       <code>  /GeneralCapabilities #complexType</code>
                       <br/>
-                      <code>  (typedef-61.1)</code>
+                      <code>  (typedef-44.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -246615,8 +246755,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-2.2">
-          <h3>43.56. The complex type <code>element[siri:OperatorPermissions]#complexType (typedef-2.2)</code>
+        <div class="sect2" id="local-type.typedef-65.2">
+          <h3>43.56. The complex type <code>element[siri:OperatorPermissions]#complexType (typedef-65.2)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -246636,7 +246776,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-2.2)</code>
+                      <code>  (typedef-65.2)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -246721,8 +246861,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-2.1">
-          <h3>43.57. The complex type <code>element[siri:LinePermissions]#complexType (typedef-2.1)</code>
+        <div class="sect2" id="local-type.typedef-65.1">
+          <h3>43.57. The complex type <code>element[siri:LinePermissions]#complexType (typedef-65.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -246742,7 +246882,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-2.1)</code>
+                      <code>  (typedef-65.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -246827,8 +246967,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-75.6">
-          <h3>43.58. The complex type <code>complexType[siri:StopMonitoringServicePermissionStructure]/StopMonitorPermissions#complexType (typedef-75.6)</code>
+        <div class="sect2" id="local-type.typedef-79.6">
+          <h3>43.58. The complex type <code>complexType[siri:StopMonitoringServicePermissionStructure]/StopMonitorPermissions#complexType (typedef-79.6)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -246848,7 +246988,7 @@
                       <br/>
                       <code>  /StopMonitorPermissions #complexType</code>
                       <br/>
-                      <code>  (typedef-75.6)</code>
+                      <code>  (typedef-79.6)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -247992,7 +248132,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-85.3" title="local-type: typedef-85.3">local-type: typedef-85.3</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-81.3" title="local-type: typedef-81.3">local-type: typedef-81.3</a>
                       </em>
                     </p>
                   </td>
@@ -249136,7 +249276,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-85.1" title="local-type: typedef-85.1">local-type: typedef-85.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-81.1" title="local-type: typedef-81.1">local-type: typedef-81.1</a>
                       </em>
                     </p>
                   </td>
@@ -249184,7 +249324,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-85.2" title="local-type: typedef-85.2">local-type: typedef-85.2</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-81.2" title="local-type: typedef-81.2">local-type: typedef-81.2</a>
                       </em>
                     </p>
                   </td>
@@ -249343,7 +249483,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-61.1" title="local-type: typedef-61.1">local-type: typedef-61.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-44.1" title="local-type: typedef-44.1">local-type: typedef-44.1</a>
                       </em>
                     </p>
                   </td>
@@ -249377,7 +249517,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-2.2" title="local-type: typedef-2.2">local-type: typedef-2.2</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-65.2" title="local-type: typedef-65.2">local-type: typedef-65.2</a>
                       </em>
                     </p>
                   </td>
@@ -249406,7 +249546,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-2.1" title="local-type: typedef-2.1">local-type: typedef-2.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-65.1" title="local-type: typedef-65.1">local-type: typedef-65.1</a>
                       </em>
                     </p>
                   </td>
@@ -249434,7 +249574,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-85.4" title="local-type: typedef-85.4">local-type: typedef-85.4</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-81.4" title="local-type: typedef-81.4">local-type: typedef-81.4</a>
                       </em>
                     </p>
                   </td>
@@ -250390,8 +250530,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-85.3">
-          <h3>44.23. The complex type <code>element[siri:StopTimetablePermissions]#complexType (typedef-85.3)</code>
+        <div class="sect2" id="local-type.typedef-81.3">
+          <h3>44.23. The complex type <code>element[siri:StopTimetablePermissions]#complexType (typedef-81.3)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -250411,7 +250551,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-85.3)</code>
+                      <code>  (typedef-81.3)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -250485,8 +250625,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-85.3">
-          <h3>44.24. The complex type <code>element[siri:StopTimetablePermissions]#complexType (typedef-85.3)</code>
+        <div class="sect2" id="local-type.typedef-81.3">
+          <h3>44.24. The complex type <code>element[siri:StopTimetablePermissions]#complexType (typedef-81.3)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -250506,7 +250646,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-85.3)</code>
+                      <code>  (typedef-81.3)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -250580,8 +250720,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-85.1">
-          <h3>44.25. The complex type <code>complexType[siri:StopTimetableServiceCapabilitiesStructure]/TopicFiltering#complexType (typedef-85.1)</code>
+        <div class="sect2" id="local-type.typedef-81.1">
+          <h3>44.25. The complex type <code>complexType[siri:StopTimetableServiceCapabilitiesStructure]/TopicFiltering#complexType (typedef-81.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -250601,7 +250741,7 @@
                       <br/>
                       <code>  /TopicFiltering #complexType</code>
                       <br/>
-                      <code>  (typedef-85.1)</code>
+                      <code>  (typedef-81.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -250695,8 +250835,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-85.2">
-          <h3>44.26. The complex type <code>complexType[siri:StopTimetableServiceCapabilitiesStructure]/AccessControl#complexType (typedef-85.2)</code>
+        <div class="sect2" id="local-type.typedef-81.2">
+          <h3>44.26. The complex type <code>complexType[siri:StopTimetableServiceCapabilitiesStructure]/AccessControl#complexType (typedef-81.2)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -250716,7 +250856,7 @@
                       <br/>
                       <code>  /AccessControl #complexType</code>
                       <br/>
-                      <code>  (typedef-85.2)</code>
+                      <code>  (typedef-81.2)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -250841,8 +250981,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-61.1">
-          <h3>44.27. The complex type <code>complexType[siri:AbstractPermissionStructure]/GeneralCapabilities#complexType (typedef-61.1)</code>
+        <div class="sect2" id="local-type.typedef-44.1">
+          <h3>44.27. The complex type <code>complexType[siri:AbstractPermissionStructure]/GeneralCapabilities#complexType (typedef-44.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -250862,7 +251002,7 @@
                       <br/>
                       <code>  /GeneralCapabilities #complexType</code>
                       <br/>
-                      <code>  (typedef-61.1)</code>
+                      <code>  (typedef-44.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -250930,8 +251070,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-2.2">
-          <h3>44.28. The complex type <code>element[siri:OperatorPermissions]#complexType (typedef-2.2)</code>
+        <div class="sect2" id="local-type.typedef-65.2">
+          <h3>44.28. The complex type <code>element[siri:OperatorPermissions]#complexType (typedef-65.2)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -250951,7 +251091,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-2.2)</code>
+                      <code>  (typedef-65.2)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -251036,8 +251176,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-2.1">
-          <h3>44.29. The complex type <code>element[siri:LinePermissions]#complexType (typedef-2.1)</code>
+        <div class="sect2" id="local-type.typedef-65.1">
+          <h3>44.29. The complex type <code>element[siri:LinePermissions]#complexType (typedef-65.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -251057,7 +251197,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-2.1)</code>
+                      <code>  (typedef-65.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -251142,8 +251282,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-85.4">
-          <h3>44.30. The complex type <code>complexType[siri:StopTimetableServicePermissionStructure]/StopMonitorPermissions#complexType (typedef-85.4)</code>
+        <div class="sect2" id="local-type.typedef-81.4">
+          <h3>44.30. The complex type <code>complexType[siri:StopTimetableServicePermissionStructure]/StopMonitorPermissions#complexType (typedef-81.4)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -251163,7 +251303,7 @@
                       <br/>
                       <code>  /StopMonitorPermissions #complexType</code>
                       <br/>
-                      <code>  (typedef-85.4)</code>
+                      <code>  (typedef-81.4)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -252564,7 +252704,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-61.1" title="local-type: typedef-61.1">local-type: typedef-61.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-44.1" title="local-type: typedef-44.1">local-type: typedef-44.1</a>
                       </em>
                     </p>
                   </td>
@@ -252692,8 +252832,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-61.1">
-          <h3>47.5. The complex type <code>complexType[siri:AbstractPermissionStructure]/GeneralCapabilities#complexType (typedef-61.1)</code>
+        <div class="sect2" id="local-type.typedef-44.1">
+          <h3>47.5. The complex type <code>complexType[siri:AbstractPermissionStructure]/GeneralCapabilities#complexType (typedef-44.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -252713,7 +252853,7 @@
                       <br/>
                       <code>  /GeneralCapabilities #complexType</code>
                       <br/>
-                      <code>  (typedef-61.1)</code>
+                      <code>  (typedef-44.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -252976,12 +253116,12 @@
                 </tr>
                 <tr>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
-                    <p id="local-type.typedef-36.1" class="tableblock">
+                    <p id="local-type.typedef-39.1" class="tableblock">
                       <code>attribute[lang]</code>
                       <br/>
                       <code>  #simpleType</code>
                       <br/>
-                      <code>  (typedef-36.1)</code>
+                      <code>  (typedef-39.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -255255,7 +255395,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-80.1" title="local-type: typedef-80.1">local-type: typedef-80.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-83.1" title="local-type: typedef-83.1">local-type: typedef-83.1</a>
                       </em>
                     </p>
                   </td>
@@ -256378,7 +256518,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-80.2" title="local-type: typedef-80.2">local-type: typedef-80.2</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-83.2" title="local-type: typedef-83.2">local-type: typedef-83.2</a>
                       </em>
                     </p>
                   </td>
@@ -256692,7 +256832,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-80.7" title="local-type: typedef-80.7">local-type: typedef-80.7</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-83.7" title="local-type: typedef-83.7">local-type: typedef-83.7</a>
                       </em>
                     </p>
                   </td>
@@ -257832,7 +257972,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-80.1" title="local-type: typedef-80.1">local-type: typedef-80.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-83.1" title="local-type: typedef-83.1">local-type: typedef-83.1</a>
                       </em>
                     </p>
                   </td>
@@ -257992,7 +258132,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-80.3" title="local-type: typedef-80.3">local-type: typedef-80.3</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-83.3" title="local-type: typedef-83.3">local-type: typedef-83.3</a>
                       </em>
                     </p>
                   </td>
@@ -258016,7 +258156,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-80.4" title="local-type: typedef-80.4">local-type: typedef-80.4</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-83.4" title="local-type: typedef-83.4">local-type: typedef-83.4</a>
                       </em>
                     </p>
                   </td>
@@ -258064,7 +258204,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-80.5" title="local-type: typedef-80.5">local-type: typedef-80.5</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-83.5" title="local-type: typedef-83.5">local-type: typedef-83.5</a>
                       </em>
                     </p>
                   </td>
@@ -258088,7 +258228,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-80.6" title="local-type: typedef-80.6">local-type: typedef-80.6</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-83.6" title="local-type: typedef-83.6">local-type: typedef-83.6</a>
                       </em>
                     </p>
                   </td>
@@ -258247,7 +258387,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-61.1" title="local-type: typedef-61.1">local-type: typedef-61.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-44.1" title="local-type: typedef-44.1">local-type: typedef-44.1</a>
                       </em>
                     </p>
                   </td>
@@ -258281,7 +258421,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-2.2" title="local-type: typedef-2.2">local-type: typedef-2.2</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-65.2" title="local-type: typedef-65.2">local-type: typedef-65.2</a>
                       </em>
                     </p>
                   </td>
@@ -258310,7 +258450,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-2.1" title="local-type: typedef-2.1">local-type: typedef-2.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-65.1" title="local-type: typedef-65.1">local-type: typedef-65.1</a>
                       </em>
                     </p>
                   </td>
@@ -258338,7 +258478,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-80.8" title="local-type: typedef-80.8">local-type: typedef-80.8</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-83.8" title="local-type: typedef-83.8">local-type: typedef-83.8</a>
                       </em>
                     </p>
                   </td>
@@ -258751,8 +258891,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-80.7">
-          <h3>50.30. The complex type <code>element[siri:VehicleMonitoringPermissions]#complexType (typedef-80.7)</code>
+        <div class="sect2" id="local-type.typedef-83.7">
+          <h3>50.30. The complex type <code>element[siri:VehicleMonitoringPermissions]#complexType (typedef-83.7)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -258772,7 +258912,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-80.7)</code>
+                      <code>  (typedef-83.7)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -258846,8 +258986,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-80.1">
-          <h3>50.31. The complex type <code>group[siri:VehicleMonitoringRequestPolicyGroup]/MaximumNumberOfCalls#complexType (typedef-80.1)</code>
+        <div class="sect2" id="local-type.typedef-83.1">
+          <h3>50.31. The complex type <code>group[siri:VehicleMonitoringRequestPolicyGroup]/MaximumNumberOfCalls#complexType (typedef-83.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -258867,7 +259007,7 @@
                       <br/>
                       <code>  /MaximumNumberOfCalls #complexType</code>
                       <br/>
-                      <code>  (typedef-80.1)</code>
+                      <code>  (typedef-83.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -258927,8 +259067,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-80.2">
-          <h3>50.32. The complex type <code>complexType[siri:VehicleActivityStructure]/MonitoredVehicleJourney#complexType (typedef-80.2)</code>
+        <div class="sect2" id="local-type.typedef-83.2">
+          <h3>50.32. The complex type <code>complexType[siri:VehicleActivityStructure]/MonitoredVehicleJourney#complexType (typedef-83.2)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -258948,7 +259088,7 @@
                       <br/>
                       <code>  /MonitoredVehicleJourney #complexType</code>
                       <br/>
-                      <code>  (typedef-80.2)</code>
+                      <code>  (typedef-83.2)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -259547,7 +259687,7 @@
                   </td>
                 </tr>
                 <tr>
-                  <td colspan="1" rowspan="4" class="tableblock halign-left valign-top">
+                  <td colspan="1" rowspan="5" class="tableblock halign-left valign-top">
                     <a shape="rect" href="#group.siri:JourneyInfoGroup" title="siri:JourneyInfoGroup">siri:JourneyInfoGroup</a>
                   </td>
                   <td colspan="2" rowspan="1" class="tableblock halign-left valign-top">
@@ -259568,6 +259708,26 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock darkbrown">For train services with named journeys. Train name, e.g. “West Coast Express”. If omitted: No train name. Inherited property. (Unbounded since SIRI 2.0)</p>
+                  </td>
+                </tr>
+                <tr>
+                  <td colspan="2" rowspan="1" class="tableblock halign-left valign-top">
+                    <p class="tableblock">
+                      <code>siri:DeadRun</code>
+                    </p>
+                  </td>
+                  <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
+                    <p class="tableblock">
+                      <span title="optional, single">0:1</span>
+                    </p>
+                  </td>
+                  <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
+                    <p class="tableblock">
+                      <em>xs:boolean</em>
+                    </p>
+                  </td>
+                  <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
+                    <p class="tableblock darkbrown">Allows to flag if the VehicleJourney is a dead run, so it is clear that only there is no expectation of an associated service to it. +v2.3</p>
                   </td>
                 </tr>
                 <tr>
@@ -260415,7 +260575,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-8.4" title="local-type: typedef-8.4">local-type: typedef-8.4</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-60.4" title="local-type: typedef-60.4">local-type: typedef-60.4</a>
                       </em>
                     </p>
                   </td>
@@ -260436,7 +260596,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-8.5" title="local-type: typedef-8.5">local-type: typedef-8.5</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-60.5" title="local-type: typedef-60.5">local-type: typedef-60.5</a>
                       </em>
                     </p>
                   </td>
@@ -260460,7 +260620,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-24.2" title="local-type: typedef-24.2">local-type: typedef-24.2</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-62.2" title="local-type: typedef-62.2">local-type: typedef-62.2</a>
                       </em>
                     </p>
                   </td>
@@ -260481,7 +260641,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-24.3" title="local-type: typedef-24.3">local-type: typedef-24.3</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-62.3" title="local-type: typedef-62.3">local-type: typedef-62.3</a>
                       </em>
                     </p>
                   </td>
@@ -260502,7 +260662,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-24.4" title="local-type: typedef-24.4">local-type: typedef-24.4</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-62.4" title="local-type: typedef-62.4">local-type: typedef-62.4</a>
                       </em>
                     </p>
                   </td>
@@ -260600,8 +260760,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-8.4">
-          <h3>50.33. The complex type <code>group[siri:TrainOperationalInfoGroup]/TrainNumbers#complexType (typedef-8.4)</code>
+        <div class="sect2" id="local-type.typedef-60.4">
+          <h3>50.33. The complex type <code>group[siri:TrainOperationalInfoGroup]/TrainNumbers#complexType (typedef-60.4)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -260621,7 +260781,7 @@
                       <br/>
                       <code>  /TrainNumbers #complexType</code>
                       <br/>
-                      <code>  (typedef-8.4)</code>
+                      <code>  (typedef-60.4)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -260663,8 +260823,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-8.5">
-          <h3>50.34. The complex type <code>group[siri:TrainOperationalInfoGroup]/JourneyParts#complexType (typedef-8.5)</code>
+        <div class="sect2" id="local-type.typedef-60.5">
+          <h3>50.34. The complex type <code>group[siri:TrainOperationalInfoGroup]/JourneyParts#complexType (typedef-60.5)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -260684,7 +260844,7 @@
                       <br/>
                       <code>  /JourneyParts #complexType</code>
                       <br/>
-                      <code>  (typedef-8.5)</code>
+                      <code>  (typedef-60.5)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -260726,8 +260886,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-24.2">
-          <h3>50.35. The complex type <code>group[siri:JourneyFormationGroup]/TrainElements#complexType (typedef-24.2)</code>
+        <div class="sect2" id="local-type.typedef-62.2">
+          <h3>50.35. The complex type <code>group[siri:JourneyFormationGroup]/TrainElements#complexType (typedef-62.2)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -260747,7 +260907,7 @@
                       <br/>
                       <code>  /TrainElements #complexType</code>
                       <br/>
-                      <code>  (typedef-24.2)</code>
+                      <code>  (typedef-62.2)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -260834,8 +260994,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-24.3">
-          <h3>50.36. The complex type <code>group[siri:JourneyFormationGroup]/Trains#complexType (typedef-24.3)</code>
+        <div class="sect2" id="local-type.typedef-62.3">
+          <h3>50.36. The complex type <code>group[siri:JourneyFormationGroup]/Trains#complexType (typedef-62.3)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -260855,7 +261015,7 @@
                       <br/>
                       <code>  /Trains #complexType</code>
                       <br/>
-                      <code>  (typedef-24.3)</code>
+                      <code>  (typedef-62.3)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -260942,8 +261102,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-24.4">
-          <h3>50.37. The complex type <code>group[siri:JourneyFormationGroup]/CompoundTrains#complexType (typedef-24.4)</code>
+        <div class="sect2" id="local-type.typedef-62.4">
+          <h3>50.37. The complex type <code>group[siri:JourneyFormationGroup]/CompoundTrains#complexType (typedef-62.4)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -260963,7 +261123,7 @@
                       <br/>
                       <code>  /CompoundTrains #complexType</code>
                       <br/>
-                      <code>  (typedef-24.4)</code>
+                      <code>  (typedef-62.4)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -261050,8 +261210,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-80.7">
-          <h3>50.38. The complex type <code>element[siri:VehicleMonitoringPermissions]#complexType (typedef-80.7)</code>
+        <div class="sect2" id="local-type.typedef-83.7">
+          <h3>50.38. The complex type <code>element[siri:VehicleMonitoringPermissions]#complexType (typedef-83.7)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -261071,7 +261231,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-80.7)</code>
+                      <code>  (typedef-83.7)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -261145,8 +261305,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-80.1">
-          <h3>50.39. The complex type <code>group[siri:VehicleMonitoringRequestPolicyGroup]/MaximumNumberOfCalls#complexType (typedef-80.1)</code>
+        <div class="sect2" id="local-type.typedef-83.1">
+          <h3>50.39. The complex type <code>group[siri:VehicleMonitoringRequestPolicyGroup]/MaximumNumberOfCalls#complexType (typedef-83.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -261166,7 +261326,7 @@
                       <br/>
                       <code>  /MaximumNumberOfCalls #complexType</code>
                       <br/>
-                      <code>  (typedef-80.1)</code>
+                      <code>  (typedef-83.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -261226,8 +261386,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-80.3">
-          <h3>50.40. The complex type <code>complexType[siri:VehicleMonitoringServiceCapabilitiesStructure]/TopicFiltering#complexType (typedef-80.3)</code>
+        <div class="sect2" id="local-type.typedef-83.3">
+          <h3>50.40. The complex type <code>complexType[siri:VehicleMonitoringServiceCapabilitiesStructure]/TopicFiltering#complexType (typedef-83.3)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -261247,7 +261407,7 @@
                       <br/>
                       <code>  /TopicFiltering #complexType</code>
                       <br/>
-                      <code>  (typedef-80.3)</code>
+                      <code>  (typedef-83.3)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -261389,8 +261549,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-80.4">
-          <h3>50.41. The complex type <code>complexType[siri:VehicleMonitoringServiceCapabilitiesStructure]/RequestPolicy#complexType (typedef-80.4)</code>
+        <div class="sect2" id="local-type.typedef-83.4">
+          <h3>50.41. The complex type <code>complexType[siri:VehicleMonitoringServiceCapabilitiesStructure]/RequestPolicy#complexType (typedef-83.4)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -261410,7 +261570,7 @@
                       <br/>
                       <code>  /RequestPolicy #complexType</code>
                       <br/>
-                      <code>  (typedef-80.4)</code>
+                      <code>  (typedef-83.4)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -261684,8 +261844,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-80.5">
-          <h3>50.42. The complex type <code>complexType[siri:VehicleMonitoringServiceCapabilitiesStructure]/AccessControl#complexType (typedef-80.5)</code>
+        <div class="sect2" id="local-type.typedef-83.5">
+          <h3>50.42. The complex type <code>complexType[siri:VehicleMonitoringServiceCapabilitiesStructure]/AccessControl#complexType (typedef-83.5)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -261705,7 +261865,7 @@
                       <br/>
                       <code>  /AccessControl #complexType</code>
                       <br/>
-                      <code>  (typedef-80.5)</code>
+                      <code>  (typedef-83.5)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -261829,8 +261989,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-80.6">
-          <h3>50.43. The complex type <code>complexType[siri:VehicleMonitoringServiceCapabilitiesStructure]/ResponseFeatures#complexType (typedef-80.6)</code>
+        <div class="sect2" id="local-type.typedef-83.6">
+          <h3>50.43. The complex type <code>complexType[siri:VehicleMonitoringServiceCapabilitiesStructure]/ResponseFeatures#complexType (typedef-83.6)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -261850,7 +262010,7 @@
                       <br/>
                       <code>  /ResponseFeatures #complexType</code>
                       <br/>
-                      <code>  (typedef-80.6)</code>
+                      <code>  (typedef-83.6)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -261910,8 +262070,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-61.1">
-          <h3>50.44. The complex type <code>complexType[siri:AbstractPermissionStructure]/GeneralCapabilities#complexType (typedef-61.1)</code>
+        <div class="sect2" id="local-type.typedef-44.1">
+          <h3>50.44. The complex type <code>complexType[siri:AbstractPermissionStructure]/GeneralCapabilities#complexType (typedef-44.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -261931,7 +262091,7 @@
                       <br/>
                       <code>  /GeneralCapabilities #complexType</code>
                       <br/>
-                      <code>  (typedef-61.1)</code>
+                      <code>  (typedef-44.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -261999,8 +262159,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-2.2">
-          <h3>50.45. The complex type <code>element[siri:OperatorPermissions]#complexType (typedef-2.2)</code>
+        <div class="sect2" id="local-type.typedef-65.2">
+          <h3>50.45. The complex type <code>element[siri:OperatorPermissions]#complexType (typedef-65.2)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -262020,7 +262180,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-2.2)</code>
+                      <code>  (typedef-65.2)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -262105,8 +262265,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-2.1">
-          <h3>50.46. The complex type <code>element[siri:LinePermissions]#complexType (typedef-2.1)</code>
+        <div class="sect2" id="local-type.typedef-65.1">
+          <h3>50.46. The complex type <code>element[siri:LinePermissions]#complexType (typedef-65.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -262126,7 +262286,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-2.1)</code>
+                      <code>  (typedef-65.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -262211,8 +262371,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-80.8">
-          <h3>50.47. The complex type <code>complexType[siri:VehicleMonitoringServicePermissionStructure]/VehicleMonitoringPermissions#complexType (typedef-80.8)</code>
+        <div class="sect2" id="local-type.typedef-83.8">
+          <h3>50.47. The complex type <code>complexType[siri:VehicleMonitoringServicePermissionStructure]/VehicleMonitoringPermissions#complexType (typedef-83.8)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -262232,7 +262392,7 @@
                       <br/>
                       <code>  /VehicleMonitoringPermissions #complexType</code>
                       <br/>
-                      <code>  (typedef-80.8)</code>
+                      <code>  (typedef-83.8)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -262415,7 +262575,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-82.2" title="local-type: typedef-82.2">local-type: typedef-82.2</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-76.2" title="local-type: typedef-76.2">local-type: typedef-76.2</a>
                       </em>
                     </p>
                   </td>
@@ -262446,7 +262606,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-70.2" title="local-type: typedef-70.2">local-type: typedef-70.2</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-22.2" title="local-type: typedef-22.2">local-type: typedef-22.2</a>
                       </em>
                     </p>
                   </td>
@@ -262832,7 +262992,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-82.4" title="local-type: typedef-82.4">local-type: typedef-82.4</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-76.4" title="local-type: typedef-76.4">local-type: typedef-76.4</a>
                       </em>
                     </p>
                   </td>
@@ -263014,8 +263174,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-83.1">
-          <h3>51.2. The complex type <code>element[siri:Siri]#complexType (typedef-83.1)</code>
+        <div class="sect2" id="local-type.typedef-84.1">
+          <h3>51.2. The complex type <code>element[siri:Siri]#complexType (typedef-84.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -263035,7 +263195,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-83.1)</code>
+                      <code>  (typedef-84.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -263113,7 +263273,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-82.2" title="local-type: typedef-82.2">local-type: typedef-82.2</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-76.2" title="local-type: typedef-76.2">local-type: typedef-76.2</a>
                       </em>
                     </p>
                   </td>
@@ -263144,7 +263304,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-70.2" title="local-type: typedef-70.2">local-type: typedef-70.2</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-22.2" title="local-type: typedef-22.2">local-type: typedef-22.2</a>
                       </em>
                     </p>
                   </td>
@@ -263530,7 +263690,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-82.4" title="local-type: typedef-82.4">local-type: typedef-82.4</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-76.4" title="local-type: typedef-76.4">local-type: typedef-76.4</a>
                       </em>
                     </p>
                   </td>
@@ -263712,8 +263872,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-82.2">
-          <h3>51.3. The complex type <code>element[siri:ServiceRequest]#complexType (typedef-82.2)</code>
+        <div class="sect2" id="local-type.typedef-76.2">
+          <h3>51.3. The complex type <code>element[siri:ServiceRequest]#complexType (typedef-76.2)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -263733,7 +263893,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-82.2)</code>
+                      <code>  (typedef-76.2)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -263967,8 +264127,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-70.2">
-          <h3>51.4. The complex type <code>element[siri:SubscriptionRequest]#complexType (typedef-70.2)</code>
+        <div class="sect2" id="local-type.typedef-22.2">
+          <h3>51.4. The complex type <code>element[siri:SubscriptionRequest]#complexType (typedef-22.2)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -263988,7 +264148,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-70.2)</code>
+                      <code>  (typedef-22.2)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -264296,8 +264456,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-82.4">
-          <h3>51.5. The complex type <code>element[siri:ServiceDelivery]#complexType (typedef-82.4)</code>
+        <div class="sect2" id="local-type.typedef-76.4">
+          <h3>51.5. The complex type <code>element[siri:ServiceDelivery]#complexType (typedef-76.4)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -264317,7 +264477,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-82.4)</code>
+                      <code>  (typedef-76.4)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -264561,7 +264721,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-68.1" title="local-type: typedef-68.1">local-type: typedef-68.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-21.1" title="local-type: typedef-21.1">local-type: typedef-21.1</a>
                       </em>
                     </p>
                   </td>
@@ -264622,8 +264782,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-68.1">
-          <h3>51.6. The complex type <code>group[siri:ServiceDeliveryRequestStatusGroup]/ErrorCondition#complexType (typedef-68.1)</code>
+        <div class="sect2" id="local-type.typedef-21.1">
+          <h3>51.6. The complex type <code>group[siri:ServiceDeliveryRequestStatusGroup]/ErrorCondition#complexType (typedef-21.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -264643,7 +264803,7 @@
                       <br/>
                       <code>  /ErrorCondition #complexType</code>
                       <br/>
-                      <code>  (typedef-68.1)</code>
+                      <code>  (typedef-21.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">

--- a/examples/siri_exm_ET/ext_estimatedTimetable_response_deadrun.xml
+++ b/examples/siri_exm_ET/ext_estimatedTimetable_response_deadrun.xml
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- EXAMPLE SIRI-ET Response
+
+	This example describes a simple response to return the vehicle position for a dead run using a SIRI-ET Service.
+
+(C) Copyright 2005-2026 CEN SIRI -->
+<Siri xmlns="http://www.siri.org.uk/siri" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="2.3" xsi:schemaLocation="http://www.siri.org.uk/siri ../../xsd/siri.xsd">
+	<ServiceDelivery>
+		<!--=======HEADER================================================== -->
+		<ResponseTimestamp>2026-07-22T09:09:26-05:00</ResponseTimestamp>
+		<ProducerRef>GT7</ProducerRef>
+		<Status>true</Status>
+		<MoreData>false</MoreData>
+		<!--=======PAYLOAD============================================== -->
+		<EstimatedTimetableDelivery version="2.3">
+			<ResponseTimestamp>2026-07-22T09:09:27-05:00</ResponseTimestamp>
+			<SubscriberRef>SAESUB</SubscriberRef>
+			<SubscriptionRef>00047</SubscriptionRef>
+			<Status>true</Status>
+			<ValidUntil>2026-07-22T10:00:00-05:00</ValidUntil>
+			<ShortestPossibleCycle>P1Y2M3DT10H30M</ShortestPossibleCycle>
+			<EstimatedJourneyVersionFrame>
+				<RecordedAtTime>2026-07-22T09:20:27-05:00</RecordedAtTime>
+				<VersionRef>5645</VersionRef>
+				<!--== Regular Journey ========================== -->
+				<EstimatedVehicleJourney>
+					<LineRef>Line456</LineRef>
+					<DirectionRef>INBOUND</DirectionRef>
+					<DatedVehicleJourneyRef>00008</DatedVehicleJourneyRef>
+					<Cancellation>false</Cancellation>
+					<PublishedLineName xml:lang="fr">Ligne 3 Metro</PublishedLineName>
+					<OperatorRef>FREX</OperatorRef>
+					<ProductCategoryRef>Cat274</ProductCategoryRef>
+					<Monitored>true</Monitored>
+					<PredictionInaccurate>false</PredictionInaccurate>
+					<DataSource>ACME</DataSource>
+					<Occupancy>seatsAvailable</Occupancy>
+					<EstimatedCalls>
+						<!-- CALL 1-->
+						<EstimatedCall>
+							<StopPointRef>00001</StopPointRef>
+							<ExtraCall>false</ExtraCall>
+							<PredictionInaccurate>false</PredictionInaccurate>
+							<Occupancy>seatsAvailable</Occupancy>
+							<BoardingStretch>false</BoardingStretch>
+							<RequestStop>false</RequestStop>
+							<AimedArrivalTime>2026-07-22T09:20:30-05:00</AimedArrivalTime>
+							<AimedDepartureTime>2001-12-17T09:21:00-05:00</AimedDepartureTime>
+						</EstimatedCall>
+						<!-- CALL 2-->
+						<EstimatedCall>
+							<StopPointRef>00002</StopPointRef>
+							<ExtraCall>false</ExtraCall>
+							<PredictionInaccurate>false</PredictionInaccurate>
+							<Occupancy>fewSeatsAvailable</Occupancy>
+							<AimedArrivalTime>2026-07-22T09:22:30-05:00</AimedArrivalTime>
+							<AimedDepartureTime>2026-07-22T09:23:00-05:00</AimedDepartureTime>
+						</EstimatedCall>
+						<!-- CALL 3 -->
+						<EstimatedCall>
+							<StopPointRef>00003</StopPointRef>
+							<PredictionInaccurate>true</PredictionInaccurate>
+							<Occupancy>full</Occupancy>
+							<AimedArrivalTime>2026-07-22T09:25:00-05:00</AimedArrivalTime>
+							<ExpectedArrivalTime>2026-07-22T09:26:30-05:00</ExpectedArrivalTime>
+							<AimedDepartureTime>2001-12-17T09:25:30-05:00</AimedDepartureTime>
+							<ExpectedDepartureTime>2001-12-17T09:27:00-05:00</ExpectedDepartureTime>
+							<DepartureBoardingActivity>noBoarding</DepartureBoardingActivity>
+						</EstimatedCall>
+					</EstimatedCalls>
+					<IsCompleteStopSequence>false</IsCompleteStopSequence>
+				</EstimatedVehicleJourney>
+				<!--== Dead run Journey ========================== -->
+				<EstimatedVehicleJourney>
+					<LineRef>Line456</LineRef>
+					<DirectionRef>INBOUND</DirectionRef>
+					<DatedVehicleJourneyRef>00009</DatedVehicleJourneyRef>
+					<Cancellation>false</Cancellation>
+					<PublishedLineName xml:lang="fr">Ligne 3 Metro</PublishedLineName>
+					<OperatorRef>FREX</OperatorRef>
+					<ProductCategoryRef>Cat274</ProductCategoryRef>
+					<DeadRun>true</DeadRun>
+					<Monitored>true</Monitored>
+					<PredictionInaccurate>false</PredictionInaccurate>
+					<DataSource>ACME</DataSource>
+					<Occupancy>notAcceptingPassengers</Occupancy>
+				</EstimatedVehicleJourney>
+			</EstimatedJourneyVersionFrame>
+		</EstimatedTimetableDelivery>
+	</ServiceDelivery>
+</Siri>

--- a/examples/siri_exm_VM/exv_vehicleMonitoring_response_deadrun.xml
+++ b/examples/siri_exm_VM/exv_vehicleMonitoring_response_deadrun.xml
@@ -28,7 +28,8 @@
 					</FramedVehicleJourneyRef>
 					<PublishedLineName xml:lang="fr">Ligne 3 Metro</PublishedLineName>
 					<DirectionName>Direction Name</DirectionName>
-					<DeadRun>true</DeadRun> <!-- a Vehicle Journey not accepting any passenger -->
+					<DeadRun>true</DeadRun>
+					<!-- a Vehicle Journey not accepting any passenger -->
 					<Monitored>true</Monitored>
 					<VehicleLocation>
 						<Longitude>1.234</Longitude>

--- a/examples/siri_exm_VM/exv_vehicleMonitoring_response_deadrun.xml
+++ b/examples/siri_exm_VM/exv_vehicleMonitoring_response_deadrun.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- EXAMPLE SIRI-VM Response
+
+	This example describes a simple response to return the vehicle position for a dead run using a SIRI-VM Service.
+
+(C) Copyright 2005-2026 CEN SIRI -->
+<Siri xmlns="http://www.siri.org.uk/siri" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="2.3" xsi:schemaLocation="http://www.siri.org.uk/siri ../../xsd/siri.xsd">
+	<ServiceDelivery>
+		<!--=======ENDPOINT ===================================== -->
+		<ResponseTimestamp>2026-07-22T09:09:26-05:00</ResponseTimestamp>
+		<ProducerRef>GT7</ProducerRef>
+		<!--=======PAYLOAD ===================================== -->
+		<VehicleMonitoringDelivery version="2.3">
+			<ResponseTimestamp>2026-07-22T09:09:27-05:00</ResponseTimestamp>
+			<SubscriberRef>SAESUB</SubscriberRef>
+			<SubscriptionRef>00047</SubscriptionRef>
+			<Status>true</Status>
+			<VehicleActivity>
+				<RecordedAtTime>2026-07-22T09:20:27-05:00</RecordedAtTime>
+				<ValidUntilTime>2026-07-22T10:00:00-05:00</ValidUntilTime>
+				<VehicleMonitoringRef>Vehicle:123456:GT7</VehicleMonitoringRef>
+				<!-- MONITORED VEHICLE JOURNEY -->
+				<MonitoredVehicleJourney>
+					<LineRef>Line456</LineRef>
+					<FramedVehicleJourneyRef>
+						<DataFrameRef>2026-07-01</DataFrameRef>
+						<DatedVehicleJourneyRef>123456</DatedVehicleJourneyRef>
+					</FramedVehicleJourneyRef>
+					<PublishedLineName xml:lang="fr">Ligne 3 Metro</PublishedLineName>
+					<DirectionName>Direction Name</DirectionName>
+					<DeadRun>true</DeadRun> <!-- a Vehicle Journey not accepting any passenger -->
+					<Monitored>true</Monitored>
+					<VehicleLocation>
+						<Longitude>1.234</Longitude>
+						<Latitude>5.678</Latitude>
+					</VehicleLocation>
+					<Bearing>234</Bearing>
+					<Occupancy>notAcceptingPassengers</Occupancy>
+				</MonitoredVehicleJourney>
+			</VehicleActivity>
+		</VehicleMonitoringDelivery>
+	</ServiceDelivery>
+</Siri>

--- a/xsd/siri_model/siri_journey.xsd
+++ b/xsd/siri_model/siri_journey.xsd
@@ -145,6 +145,11 @@ Rail transport, Roads and road transport
 					<xsd:documentation>For train services with named journeys. Train name, e.g. “West Coast Express”. If omitted: No train name. Inherited property.  (Unbounded since SIRI 2.0)</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
+			<xsd:element name="DeadRun" type="xsd:boolean" default="false" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>Allows to flag if the VehicleJourney is a dead run, so it is clear that only there is no expectation of an associated service to it. +v2.3</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
 			<xsd:element ref="JourneyNote" minOccurs="0" maxOccurs="unbounded"/>
 			<xsd:element name="PublicContact" type="SimpleContactStructure" minOccurs="0">
 				<xsd:annotation>


### PR DESCRIPTION
# Context

Since we have the possibility to have dead runs in NeTEx, it would be interesting to be able to follow them in SIRI-VM (mostly) and in SIRI-ET. It would allow to  address these use cases:
- Have an explicit mention of a dead run that can be used for passenger information, especially when unplanned
- Support fleet monitoring regardless of the ServiceJourney type (accepting passengers or not).

# Changes made in this PR

- In the XSD, more precisely in `siri_journey.xsd` in the `JourneyInfoGroup`, addition of an optional boolean named `DeadRun7 with the default value being `false`
- One example of a payload in SIRI-ET that includes a dead run
- One example of a payload in SIRI-VM that includes a dead run